### PR TITLE
Teams - Phase out old player count logic

### DIFF
--- a/src/main/kotlin/dartzee/db/DartsMatchEntity.kt
+++ b/src/main/kotlin/dartzee/db/DartsMatchEntity.kt
@@ -95,12 +95,7 @@ class DartsMatchEntity(database: Database = mainDatabase) : AbstractEntity<Darts
         return count == games
     }
 
-    fun getPlayerCount(): Int = players.size
-
-    fun getMatchDesc(): String
-    {
-        return "Match #$localId (${getMatchTypeDesc()} - ${gameType.getDescription(gameParams)}, ${getPlayerCount()} players)"
-    }
+    fun getMatchDesc() = "Match #$localId (${getMatchTypeDesc()} - ${gameType.getDescription(gameParams)})"
 
     private fun getMatchTypeDesc() =
         when(mode)
@@ -158,15 +153,8 @@ class DartsMatchEntity(database: Database = mainDatabase) : AbstractEntity<Darts
         /**
          * Factory methods
          */
-        fun factoryFirstTo(games: Int): DartsMatchEntity
-        {
-            return factoryAndSave(games, MatchMode.FIRST_TO, "")
-        }
-
-        fun factoryPoints(games: Int, pointsJson: String): DartsMatchEntity
-        {
-            return factoryAndSave(games, MatchMode.POINTS, pointsJson)
-        }
+        fun factoryFirstTo(games: Int) = factoryAndSave(games, MatchMode.FIRST_TO, "")
+        fun factoryPoints(games: Int, pointsJson: String) = factoryAndSave(games, MatchMode.POINTS, pointsJson)
 
         private fun factoryAndSave(games: Int, mode: MatchMode, matchParams: String): DartsMatchEntity
         {

--- a/src/main/kotlin/dartzee/db/GameEntity.kt
+++ b/src/main/kotlin/dartzee/db/GameEntity.kt
@@ -69,18 +69,11 @@ class GameEntity(database: Database = mainDatabase): AbstractEntity<GameEntity>(
     fun isFinished() = !isEndOfTime(dtFinish)
     fun getTypeDesc() = gameType.getDescription(gameParams)
 
-    fun retrievePlayersVector(): MutableList<PlayerEntity>
+    fun retrievePlayersVector(): List<PlayerEntity>
     {
-        val ret = mutableListOf<PlayerEntity>()
-
         val whereSql = "GameId = '$rowId' ORDER BY Ordinal ASC"
         val participants = ParticipantEntity().retrieveEntities(whereSql)
-
-        participants.forEach{
-            ret.add(it.getPlayer())
-        }
-
-        return ret
+        return participants.map { it.getPlayer() }
     }
 
     companion object

--- a/src/main/kotlin/dartzee/game/GameLauncher.kt
+++ b/src/main/kotlin/dartzee/game/GameLauncher.kt
@@ -25,7 +25,7 @@ class GameLauncher
 
         insertDartzeeRules(game.rowId, dartzeeDtos)
 
-        val panel = scrn.addGameToMatch(game)
+        val panel = scrn.addGameToMatch(game, match.players.size)
         panel.startNewGame(match.players)
     }
 
@@ -104,7 +104,7 @@ class GameLauncher
         try
         {
             allGames.forEach {
-                val panel = scrn.addGameToMatch(it)
+                val panel = scrn.addGameToMatch(it, it.retrievePlayersVector().size)
                 panel.loadGame()
             }
 

--- a/src/main/kotlin/dartzee/screen/game/AbstractDartsGameScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/AbstractDartsGameScreen.kt
@@ -1,34 +1,21 @@
 package dartzee.screen.game
 
 import dartzee.achievements.AbstractAchievement
-import dartzee.game.GameType
 import dartzee.screen.FocusableWindow
 import dartzee.screen.ScreenCache
-import dartzee.screen.game.scorer.SCORER_WIDTH
-import java.awt.Dimension
 import java.awt.Frame
 import java.awt.event.WindowEvent
 import java.awt.event.WindowListener
 import javax.swing.WindowConstants
 
-abstract class AbstractDartsGameScreen(totalPlayers: Int, val gameType: GameType): FocusableWindow(), WindowListener
+abstract class AbstractDartsGameScreen : FocusableWindow(), WindowListener
 {
     var haveLostFocus = false
 
     init
     {
-        setScreenSize(totalPlayers)
-
         defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
         addWindowListener(this)
-    }
-
-    open fun getScreenHeight() = if (gameType == GameType.DARTZEE) 795 else 675
-    private fun setScreenSize(playerCount: Int)
-    {
-        val newSize = Dimension(520 + (playerCount * (SCORER_WIDTH + 4)), getScreenHeight())
-        size = newSize
-        isResizable = false
     }
 
     /**

--- a/src/main/kotlin/dartzee/screen/game/DartsGameScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGameScreen.kt
@@ -8,7 +8,7 @@ import dartzee.screen.ScreenCache
  * DartsGameScreen
  * Simple screen which wraps up a single game panel
  */
-class DartsGameScreen(game: GameEntity, totalPlayers: Int) : AbstractDartsGameScreen(totalPlayers, game.gameType)
+class DartsGameScreen(game: GameEntity, totalPlayers: Int) : AbstractDartsGameScreen()
 {
     var gamePanel: DartsGamePanel<*, *, *> = DartsGamePanel.factory(this, game, totalPlayers)
     override val windowName = gamePanel.gameTitle

--- a/src/main/kotlin/dartzee/screen/game/dartzee/DartzeeMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/dartzee/DartzeeMatchScreen.kt
@@ -11,5 +11,6 @@ import dartzee.screen.game.MatchSummaryPanel
 class DartzeeMatchScreen(match: DartsMatchEntity):
     DartsMatchScreen<DartzeePlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelDartzee()), match)
 {
-    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = constructGamePanelDartzee(parent, game, match.getPlayerCount())
+    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int) =
+        constructGamePanelDartzee(parent, game, totalPlayers)
 }

--- a/src/main/kotlin/dartzee/screen/game/golf/GolfMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GolfMatchScreen.kt
@@ -10,5 +10,6 @@ import dartzee.screen.game.MatchSummaryPanel
 class GolfMatchScreen(match: DartsMatchEntity):
     DartsMatchScreen<GolfPlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelGolf()), match)
 {
-    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = GamePanelGolf(parent, game, match.getPlayerCount())
+    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int) =
+        GamePanelGolf(parent, game, totalPlayers)
 }

--- a/src/main/kotlin/dartzee/screen/game/rtc/RoundTheClockMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/RoundTheClockMatchScreen.kt
@@ -10,5 +10,6 @@ import dartzee.screen.game.MatchSummaryPanel
 class RoundTheClockMatchScreen(match: DartsMatchEntity):
     DartsMatchScreen<ClockPlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelRoundTheClock(match.gameParams)), match)
 {
-    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = GamePanelRoundTheClock(parent, game, match.getPlayerCount())
+    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int) =
+        GamePanelRoundTheClock(parent, game, totalPlayers)
 }

--- a/src/main/kotlin/dartzee/screen/game/x01/X01MatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/x01/X01MatchScreen.kt
@@ -10,5 +10,6 @@ import dartzee.screen.game.MatchSummaryPanel
 class X01MatchScreen(match: DartsMatchEntity):
     DartsMatchScreen<X01PlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelX01(match.gameParams)), match)
 {
-    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = GamePanelX01(parent, game, match.getPlayerCount())
+    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int) =
+        GamePanelX01(parent, game, totalPlayers)
 }

--- a/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
@@ -115,16 +115,6 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
     }
 
     @Test
-    fun `Should return the number of players in the match`()
-    {
-        val dm = DartsMatchEntity()
-        dm.getPlayerCount() shouldBe 0
-
-        dm.players = listOf(PlayerEntity())
-        dm.getPlayerCount() shouldBe 1
-    }
-
-    @Test
     fun `FIRST_TO descriptions`()
     {
         val dm = DartsMatchEntity()
@@ -134,7 +124,7 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
         dm.gameType = GameType.X01
         dm.gameParams = "501"
 
-        dm.getMatchDesc() shouldBe "Match #1 (First to 3 - 501, 0 players)"
+        dm.getMatchDesc() shouldBe "Match #1 (First to 3 - 501)"
     }
 
     @Test
@@ -147,7 +137,7 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
         dm.gameType = GameType.GOLF
         dm.gameParams = "18"
 
-        dm.getMatchDesc() shouldBe "Match #1 (Points based (3 games) - Golf - 18 holes, 0 players)"
+        dm.getMatchDesc() shouldBe "Match #1 (Points based (3 games) - Golf - 18 holes)"
     }
 
     @Test

--- a/src/test/kotlin/dartzee/screen/game/GameTestFactory.kt
+++ b/src/test/kotlin/dartzee/screen/game/GameTestFactory.kt
@@ -38,7 +38,7 @@ fun makeTeam(vararg players: PlayerEntity): TeamParticipant
 
 fun makeGolfGamePanel(currentPlayerId: String = randomGuid()) =
     GamePanelGolf(
-        FakeDartsScreen(GameType.GOLF),
+        FakeDartsScreen(),
         GameEntity.factoryAndSave(GameType.GOLF, "18"),
         1).apply { testInit(currentPlayerId) }
 
@@ -47,7 +47,7 @@ fun makeX01GamePanel(currentPlayerId: String = randomGuid()) =
 
 fun makeRoundTheClockGamePanel(playerId: String = randomGuid()) =
     GamePanelRoundTheClock(
-        FakeDartsScreen(GameType.ROUND_THE_CLOCK),
+        FakeDartsScreen(),
         GameEntity.factoryAndSave(GameType.ROUND_THE_CLOCK, RoundTheClockConfig(ClockType.Standard, true).toJson()),
         1).apply { testInit(playerId) }
 
@@ -69,7 +69,7 @@ fun DartsGamePanel<*, *, *>.addCompletedRound(dartsThrown: List<Dart>)
     btnConfirm.doClick()
 }
 
-class FakeDartsScreen(gameType: GameType = GameType.X01) : AbstractDartsGameScreen(2, gameType)
+class FakeDartsScreen() : AbstractDartsGameScreen()
 {
     override val windowName = "Fake"
 

--- a/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
@@ -170,7 +170,7 @@ private class FakeMatchScreen(match: DartsMatchEntity,
                               matchSummaryPanel: MatchSummaryPanel<X01PlayerState>):
         DartsMatchScreen<X01PlayerState>(matchSummaryPanel, match)
 {
-    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity): GamePanelX01
+    override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int): GamePanelX01
     {
         val panel = mockk<GamePanelX01>(relaxed = true)
         every { panel.gameEntity } returns game
@@ -182,7 +182,7 @@ private class FakeMatchScreen(match: DartsMatchEntity,
     {
         var panel: DartsGamePanel<*, *, *>? = null
         SwingUtilities.invokeAndWait {
-            panel = addGameToMatch(gameEntity)
+            panel = addGameToMatch(gameEntity, 2)
         }
 
         return panel!!

--- a/src/test/kotlin/e2e/TestMatchE2E.kt
+++ b/src/test/kotlin/e2e/TestMatchE2E.kt
@@ -94,7 +94,7 @@ class TestMatchE2E: AbstractRegistryTest()
     private fun verifyUi()
     {
         val matchScreen = ScreenCache.getDartsGameScreens().first() as X01MatchScreen
-        matchScreen.title shouldBe "Match #1 (First to 2 - 501, 2 players)"
+        matchScreen.title shouldBe "Match #1 (First to 2 - 501)"
 
         val summaryPanel = matchScreen.getChild<MatchSummaryPanel<*>>()
         val winnerScorer = summaryPanel.getChild<MatchScorer> { it.playerName == "Winner" }


### PR DESCRIPTION
Prefactor so that the player count is something that's passed in from places where we'll have access to the full participant list, rather than being recalculated on the fly based on player count (which will no longer work in team games).