### PR TITLE
Teams - Some UI polishing

### DIFF
--- a/src/main/kotlin/dartzee/game/UniqueParticipantName.kt
+++ b/src/main/kotlin/dartzee/game/UniqueParticipantName.kt
@@ -6,8 +6,3 @@ import dartzee.types.StringMicrotype
  * The team name in a deterministic order - does not vary based on throw order
  */
 class UniqueParticipantName(value: String) : StringMicrotype(value)
-
-/**
- * The team name for a particular game - varies based on throw order
- */
-class ParticipantName(value: String) : StringMicrotype(value)

--- a/src/main/kotlin/dartzee/game/state/IWrappedParticipant.kt
+++ b/src/main/kotlin/dartzee/game/state/IWrappedParticipant.kt
@@ -3,7 +3,6 @@ package dartzee.game.state
 import dartzee.db.IParticipant
 import dartzee.db.ParticipantEntity
 import dartzee.db.TeamEntity
-import dartzee.game.ParticipantName
 import dartzee.game.UniqueParticipantName
 import dartzee.utils.splitAvatar
 import javax.swing.ImageIcon
@@ -22,7 +21,21 @@ sealed interface IWrappedParticipant
     fun ordinal() = participant.ordinal
     fun getIndividual(roundNumber: Int): ParticipantEntity
     fun getUniqueParticipantName() = UniqueParticipantName(individuals.map { it.getPlayerName() }.sorted().joinToString(" & "))
-    fun getParticipantName() = ParticipantName(individuals.joinToString(" & ") { it.getPlayerName() })
+    fun getParticipantNameHtml(active: Boolean, currentParticipant: ParticipantEntity? = null): String
+    {
+        val contents = individuals.joinToString(" &#38; ") { pt ->
+            if (active && pt == currentParticipant)
+            {
+                "<b>${pt.getPlayerName()}</b>"
+            }
+            else
+            {
+                pt.getPlayerName()
+            }
+        }
+
+        return "<html>$contents</html>"
+    }
     fun getAvatar(roundNumber: Int, selected: Boolean): ImageIcon
 }
 

--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -1,19 +1,25 @@
 package dartzee.screen.game
 
-import dartzee.`object`.Dart
-import dartzee.`object`.SegmentType
 import dartzee.achievements.AbstractAchievement
 import dartzee.achievements.getBestGameAchievement
 import dartzee.achievements.getWinAchievementType
 import dartzee.ai.DartsAiModel
 import dartzee.bean.SliderAiSpeed
 import dartzee.core.obj.HashMapList
-import dartzee.core.util.*
-import dartzee.db.*
+import dartzee.core.util.doBadMiss
+import dartzee.core.util.doBull
+import dartzee.core.util.getSortedValues
+import dartzee.core.util.getSqlDateNow
+import dartzee.core.util.isEndOfTime
+import dartzee.db.AchievementEntity
+import dartzee.db.DartzeeRuleEntity
+import dartzee.db.GameEntity
 import dartzee.game.GameType
 import dartzee.game.state.AbstractPlayerState
 import dartzee.game.state.IWrappedParticipant
 import dartzee.listener.DartboardListener
+import dartzee.`object`.Dart
+import dartzee.`object`.SegmentType
 import dartzee.screen.Dartboard
 import dartzee.screen.game.dartzee.DartzeeRuleCarousel
 import dartzee.screen.game.dartzee.DartzeeRuleSummaryPanel
@@ -36,7 +42,12 @@ import java.awt.event.ActionListener
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.sql.SQLException
-import javax.swing.*
+import javax.swing.ImageIcon
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.JToggleButton
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
 
 abstract class DartsGamePanel<S : AbstractDartsScorer<PlayerState>, D: Dartboard, PlayerState: AbstractPlayerState<PlayerState>>(
         protected val parentWindow: AbstractDartsGameScreen,
@@ -103,7 +114,7 @@ abstract class DartsGamePanel<S : AbstractDartsScorer<PlayerState>, D: Dartboard
     fun getDartsThrown() = getCurrentPlayerState().currentRound
     fun dartsThrownCount() = getDartsThrown().size
 
-    protected fun addState(playerNumber: Int, state: PlayerState, scorer: S) {
+    private fun addState(playerNumber: Int, state: PlayerState, scorer: S) {
         hmPlayerNumberToState[playerNumber] = state
         hmPlayerNumberToScorer[playerNumber] = scorer
     }
@@ -667,7 +678,7 @@ abstract class DartsGamePanel<S : AbstractDartsScorer<PlayerState>, D: Dartboard
 
     fun achievementUnlocked(playerId: String, achievement: AbstractAchievement)
     {
-        scorersOrdered.find { it.playerIds.contains(playerId) }?.achievementUnlocked(achievement)
+        scorersOrdered.find { it.playerIds.contains(playerId) }?.achievementUnlocked(achievement, playerId)
     }
 
     private fun dismissSlider()

--- a/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorer.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorer.kt
@@ -8,7 +8,10 @@ import dartzee.game.state.AbstractPlayerState
 import dartzee.game.state.IWrappedParticipant
 import dartzee.game.state.PlayerStateListener
 import net.miginfocom.swing.MigLayout
-import java.awt.*
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
 import java.awt.event.MouseEvent
@@ -37,7 +40,7 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
     {
         runOnEventThreadBlocking {
             model.clear()
-            setSelected(state.isActive, state.currentRoundNumber())
+            setSelected(state)
 
             stateChangedImpl(state)
 
@@ -55,10 +58,11 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
         updateResultColourForPosition(state.wrappedParticipant.participant.finishingPosition)
     }
 
-    private fun setSelected(selected: Boolean, roundNumber: Int)
+    private fun setSelected(state: PlayerState)
     {
-        lblName.foreground = if (selected) Color.RED else Color.BLACK
-        lblAvatar.setSelected(selected, roundNumber)
+        val currentIndividual = state.currentIndividual()
+        lblName.text = state.wrappedParticipant.getParticipantNameHtml(state.isActive, currentIndividual)
+        lblAvatar.setSelected(state.isActive, state.currentRoundNumber())
     }
 
     protected open fun stateChangedImpl(state: PlayerState) {}

--- a/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorer.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorer.kt
@@ -1,27 +1,13 @@
 package dartzee.screen.game.scorer
 
 import dartzee.achievements.AbstractAchievement
-import dartzee.bean.AchievementMedal
-import dartzee.core.bean.SwingLabel
 import dartzee.core.util.runOnEventThreadBlocking
 import dartzee.game.state.AbstractPlayerState
 import dartzee.game.state.IWrappedParticipant
 import dartzee.game.state.PlayerStateListener
-import net.miginfocom.swing.MigLayout
 import java.awt.BorderLayout
 import java.awt.Dimension
-import java.awt.FlowLayout
-import java.awt.Font
-import java.awt.event.ActionEvent
-import java.awt.event.ActionListener
-import java.awt.event.MouseEvent
-import java.awt.event.MouseListener
-import javax.swing.JButton
-import javax.swing.JLabel
-import javax.swing.JPanel
-import javax.swing.border.BevelBorder
 import javax.swing.border.EmptyBorder
-import javax.swing.border.LineBorder
 
 const val SCORER_WIDTH = 210
 
@@ -32,7 +18,7 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
 
     init
     {
-        preferredSize = Dimension(SCORER_WIDTH, 600)
+        preferredSize = Dimension(SCORER_WIDTH, 700)
         panelAvatar.border = EmptyBorder(5, 30, 5, 30)
     }
 
@@ -67,9 +53,10 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
 
     protected open fun stateChangedImpl(state: PlayerState) {}
 
-    fun achievementUnlocked(achievement: AbstractAchievement)
+    fun achievementUnlocked(achievement: AbstractAchievement, playerId: String)
     {
-        val overlay = AchievementOverlay(achievement)
+        val playerName = getPlayerNameIfNecessary(playerId)
+        val overlay = AchievementOverlay(this, achievement, playerName)
 
         overlays.add(overlay)
 
@@ -80,116 +67,38 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
         panelCenter.revalidate()
         panelCenter.repaint()
     }
+    private fun getPlayerNameIfNecessary(playerId: String): String?
+    {
+        if (participant.individuals.size == 1)
+        {
+            return null
+        }
+
+        val pt = participant.individuals.first { it.playerId == playerId }
+        return pt.getPlayerName()
+    }
+
+    fun achievementClosed(overlay: AchievementOverlay)
+    {
+        panelCenter.removeAll()
+        overlays.remove(overlay)
+
+        //If there are more overlays stacked 'beneath', show the next one of them now
+        if (overlays.isNotEmpty())
+        {
+            panelCenter.add(overlays.last(), BorderLayout.CENTER)
+        }
+        else
+        {
+            allAchievementsClosed()
+        }
+
+        panelCenter.revalidate()
+        panelCenter.repaint()
+    }
 
     open fun allAchievementsClosed()
     {
         panelCenter.add(tableScores)
-    }
-
-    inner class AchievementOverlay(achievement: AbstractAchievement) : JPanel(), ActionListener, MouseListener
-    {
-        private val btnClose = JButton("X")
-        private val fillColor = achievement.getColor(false).brighter()
-        private val borderColor = fillColor.darker()
-
-        init
-        {
-            layout = BorderLayout(0, 0)
-            border = LineBorder(borderColor, 6)
-
-            background = fillColor
-            val panelNorth = JPanel()
-            panelNorth.background = fillColor
-
-            add(panelNorth, BorderLayout.NORTH)
-            val fl = FlowLayout()
-            fl.alignment = FlowLayout.TRAILING
-            panelNorth.layout = fl
-
-            panelNorth.add(btnClose)
-
-            btnClose.font = Font("Trebuchet MS", Font.BOLD, 16)
-            btnClose.preferredSize = Dimension(40, 40)
-            btnClose.background = fillColor
-            btnClose.foreground = borderColor.darker()
-            btnClose.isContentAreaFilled = false
-            btnClose.border = BevelBorder(BevelBorder.RAISED, borderColor, borderColor.darker())
-
-            val panelCenter = JPanel()
-            add(panelCenter, BorderLayout.CENTER)
-            panelCenter.layout = MigLayout("", "[grow]", "[][][][]")
-            panelCenter.background = fillColor
-
-            val medal = AchievementMedal(achievement, false)
-            medal.preferredSize = Dimension(175, 200)
-            panelCenter.add(medal, "cell 0 2, alignx center")
-
-            val lblAchievement = factoryTextLabel("Achievement")
-            panelCenter.add(lblAchievement, "cell 0 0")
-
-            val lblUnlocked = factoryTextLabel("Unlocked!")
-            lblUnlocked.preferredSize = Dimension(200, 50)
-            lblUnlocked.verticalAlignment = JLabel.TOP
-            panelCenter.add(lblUnlocked, "cell 0 1")
-
-            val lbName = factoryTextLabel(achievement.name, 20, "achievementName")
-            panelCenter.add(lbName, "cell 0 3")
-
-            btnClose.addMouseListener(this)
-            btnClose.addActionListener(this)
-        }
-
-        private fun factoryTextLabel(text: String, fontSize: Int = 24, testId: String = "") : JLabel
-        {
-            val lbl = SwingLabel(text, testId)
-            lbl.background = fillColor
-            lbl.foreground = borderColor.darker()
-            lbl.horizontalAlignment = JLabel.CENTER
-            lbl.font = Font("Trebuchet MS", Font.BOLD, fontSize)
-            lbl.preferredSize = Dimension(200, 30)
-            return lbl
-        }
-
-        override fun actionPerformed(e: ActionEvent)
-        {
-            panelCenter.removeAll()
-            overlays.remove(this)
-
-            //If there are more overlays stacked 'beneath', show the next one of them now
-            if (overlays.isNotEmpty())
-            {
-                panelCenter.add(overlays.last(), BorderLayout.CENTER)
-            }
-            else
-            {
-                allAchievementsClosed()
-            }
-
-            panelCenter.revalidate()
-            panelCenter.repaint()
-            revalidate()
-            repaint()
-        }
-
-        override fun mousePressed(e: MouseEvent?)
-        {
-            btnClose.foreground = borderColor.darker().darker()
-            btnClose.background = fillColor.darker()
-            btnClose.border = BevelBorder(BevelBorder.LOWERED, borderColor.darker(), borderColor.darker().darker())
-            btnClose.repaint()
-        }
-
-        override fun mouseReleased(e: MouseEvent?)
-        {
-            btnClose.background = fillColor
-            btnClose.foreground = borderColor.darker()
-            btnClose.border = BevelBorder(BevelBorder.RAISED, borderColor, borderColor.darker())
-            btnClose.repaint()
-        }
-
-        override fun mouseClicked(e: MouseEvent?) {}
-
-        override fun mouseEntered(e: MouseEvent?) {}
-        override fun mouseExited(e: MouseEvent?) {}
     }
 }

--- a/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorerPausable.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorerPausable.kt
@@ -45,12 +45,12 @@ abstract class AbstractDartsScorerPausable<PlayerState: AbstractPlayerState<Play
     {
         if (btnResume.icon === ICON_PAUSE)
         {
-            logger.info(CODE_PLAYER_PAUSED, "Paused player ${participant.getParticipantName()}")
+            logger.info(CODE_PLAYER_PAUSED, "Paused player ${participant.getUniqueParticipantName()}")
             btnResume.icon = ICON_RESUME
         }
         else
         {
-            logger.info(CODE_PLAYER_UNPAUSED, "Unpaused player ${participant.getParticipantName()}")
+            logger.info(CODE_PLAYER_UNPAUSED, "Unpaused player ${participant.getUniqueParticipantName()}")
             btnResume.icon = ICON_PAUSE
             updateResultColourForPosition(-1)
         }

--- a/src/main/kotlin/dartzee/screen/game/scorer/AbstractScorer.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AbstractScorer.kt
@@ -46,8 +46,9 @@ abstract class AbstractScorer(val participant: IWrappedParticipant) : JPanel(), 
         panelNorth.add(lblName, BorderLayout.NORTH)
         lblName.horizontalAlignment = SwingConstants.CENTER
         lblName.font = Font("Trebuchet MS", Font.PLAIN, 16)
-        lblName.text = participant.getParticipantName().value
+        lblName.text = participant.getParticipantNameHtml(false)
         lblName.foreground = Color.BLACK
+        lblName.border = EmptyBorder(10, 0, 0, 0)
         panelAvatar.border = EmptyBorder(5, 15, 5, 15)
         panelNorth.add(panelAvatar, BorderLayout.CENTER)
         panelAvatar.layout = BorderLayout(0, 0)

--- a/src/main/kotlin/dartzee/screen/game/scorer/AchievementOverlay.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AchievementOverlay.kt
@@ -1,0 +1,119 @@
+package dartzee.screen.game.scorer
+
+import dartzee.achievements.AbstractAchievement
+import dartzee.bean.AchievementMedal
+import dartzee.core.bean.SwingLabel
+import net.miginfocom.swing.MigLayout
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.event.ActionEvent
+import java.awt.event.ActionListener
+import java.awt.event.MouseEvent
+import java.awt.event.MouseListener
+import javax.swing.JButton
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.border.BevelBorder
+import javax.swing.border.LineBorder
+
+class AchievementOverlay(private val parent: AbstractDartsScorer<*>, achievement: AbstractAchievement, playerName: String?) : JPanel(), ActionListener, MouseListener
+{
+    private val btnClose = JButton("X")
+    private val fillColor = achievement.getColor(false).brighter()
+    private val borderColor = fillColor.darker()
+
+    init
+    {
+        layout = BorderLayout(0, 0)
+        border = LineBorder(borderColor, 6)
+        size = Dimension(SCORER_WIDTH, 500)
+
+        background = fillColor
+        val panelNorth = JPanel()
+        panelNorth.background = fillColor
+
+        add(panelNorth, BorderLayout.NORTH)
+        val fl = FlowLayout()
+        fl.alignment = FlowLayout.TRAILING
+        panelNorth.layout = fl
+
+        panelNorth.add(btnClose)
+
+        btnClose.font = Font("Trebuchet MS", Font.BOLD, 16)
+        btnClose.preferredSize = Dimension(40, 40)
+        btnClose.background = fillColor
+        btnClose.foreground = borderColor.darker()
+        btnClose.isContentAreaFilled = false
+        btnClose.border = BevelBorder(BevelBorder.RAISED, borderColor, borderColor.darker())
+
+        val panelCenter = JPanel()
+        add(panelCenter, BorderLayout.CENTER)
+        panelCenter.layout = MigLayout("", "[grow]", "[][][][]")
+        panelCenter.background = fillColor
+
+        val medal = AchievementMedal(achievement, false)
+        medal.preferredSize = Dimension(175, 200)
+        panelCenter.add(medal, "cell 0 2, alignx center")
+
+        val lblAchievement = factoryTextLabel("Achievement")
+        panelCenter.add(lblAchievement, "cell 0 0")
+
+        val lblUnlocked = factoryTextLabel("Unlocked!")
+        lblUnlocked.preferredSize = Dimension(200, 50)
+        lblUnlocked.verticalAlignment = JLabel.TOP
+        panelCenter.add(lblUnlocked, "cell 0 1")
+
+        if (playerName != null)
+        {
+            val lblPlayerName = factoryTextLabel(playerName, 20, "playerName")
+            panelCenter.add(lblPlayerName, "cell 0 3")
+        }
+
+        val lbName = factoryTextLabel(achievement.name, 16, "achievementName")
+        panelCenter.add(lbName, "cell 0 4")
+
+        btnClose.addMouseListener(this)
+        btnClose.addActionListener(this)
+    }
+
+    private fun factoryTextLabel(text: String, fontSize: Int = 24, testId: String = "") : JLabel
+    {
+        val lbl = SwingLabel(text, testId)
+        lbl.background = fillColor
+        lbl.foreground = borderColor.darker()
+        lbl.horizontalAlignment = JLabel.CENTER
+        lbl.font = Font("Trebuchet MS", Font.BOLD, fontSize)
+        lbl.preferredSize = Dimension(200, 30)
+        return lbl
+    }
+
+    override fun actionPerformed(e: ActionEvent)
+    {
+        parent.achievementClosed(this)
+        revalidate()
+        repaint()
+    }
+
+    override fun mousePressed(e: MouseEvent?)
+    {
+        btnClose.foreground = borderColor.darker().darker()
+        btnClose.background = fillColor.darker()
+        btnClose.border = BevelBorder(BevelBorder.LOWERED, borderColor.darker(), borderColor.darker().darker())
+        btnClose.repaint()
+    }
+
+    override fun mouseReleased(e: MouseEvent?)
+    {
+        btnClose.background = fillColor
+        btnClose.foreground = borderColor.darker()
+        btnClose.border = BevelBorder(BevelBorder.RAISED, borderColor, borderColor.darker())
+        btnClose.repaint()
+    }
+
+    override fun mouseClicked(e: MouseEvent?) {}
+
+    override fun mouseEntered(e: MouseEvent?) {}
+    override fun mouseExited(e: MouseEvent?) {}
+}

--- a/src/main/kotlin/dartzee/screen/game/scorer/AchievementOverlay.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AchievementOverlay.kt
@@ -28,7 +28,6 @@ class AchievementOverlay(private val parent: AbstractDartsScorer<*>, achievement
     {
         layout = BorderLayout(0, 0)
         border = LineBorder(borderColor, 6)
-        size = Dimension(SCORER_WIDTH, 500)
 
         background = fillColor
         val panelNorth = JPanel()

--- a/src/test/kotlin/dartzee/achievements/x01/TestAchievementX01CheckoutCompleteness.kt
+++ b/src/test/kotlin/dartzee/achievements/x01/TestAchievementX01CheckoutCompleteness.kt
@@ -35,7 +35,7 @@ class TestAchievementX01CheckoutCompleteness: AbstractMultiRowAchievementTest<Ac
     fun `Should ignore non-checkout darts`()
     {
         val g = insertRelevantGame()
-        val pt = insertParticipant(gameId = g.rowId, insertPlayer = true)
+        val pt = insertParticipant(gameId = g.rowId)
 
         insertDart(pt, roundNumber = 1, startingScore = 100, score = 1, multiplier = 2)
         insertDart(pt, roundNumber = 1, startingScore = 2, score = 2, multiplier = 1)

--- a/src/test/kotlin/dartzee/game/state/TestAbstractPlayerState.kt
+++ b/src/test/kotlin/dartzee/game/state/TestAbstractPlayerState.kt
@@ -1,7 +1,5 @@
 package dartzee.game.state
 
-import dartzee.`object`.Dart
-import dartzee.`object`.SegmentType
 import dartzee.core.helper.verifyNotCalled
 import dartzee.core.util.DateStatics
 import dartzee.db.DartEntity
@@ -17,6 +15,8 @@ import dartzee.helper.AbstractTest
 import dartzee.helper.insertParticipant
 import dartzee.helper.insertPlayer
 import dartzee.helper.insertTeam
+import dartzee.`object`.Dart
+import dartzee.`object`.SegmentType
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.shouldBe
@@ -70,7 +70,7 @@ class TestAbstractPlayerState: AbstractTest()
     @Test
     fun `Should support committing a round of darts and saving them to the database`()
     {
-        val pt = insertParticipant(insertPlayer = true)
+        val pt = insertParticipant()
         val dartOne = Dart(20, 1, Point(50, 50), SegmentType.OUTER_SINGLE)
         val dartTwo = Dart(5, 1, Point(40, 45), SegmentType.OUTER_SINGLE)
         val dartThree = Dart(1, 1, Point(60, 45), SegmentType.OUTER_SINGLE)

--- a/src/test/kotlin/dartzee/game/state/TestSingleParticipant.kt
+++ b/src/test/kotlin/dartzee/game/state/TestSingleParticipant.kt
@@ -19,6 +19,7 @@ class TestSingleParticipant: AbstractTest()
         singlePt.getIndividual(1) shouldBe pt
         singlePt.getIndividual(2) shouldBe pt
         singlePt.getUniqueParticipantName().value shouldBe "Alyssa"
-        singlePt.getParticipantName().value shouldBe "Alyssa"
+        singlePt.getParticipantNameHtml(false) shouldBe "<html>Alyssa</html>"
+        singlePt.getParticipantNameHtml(true, pt) shouldBe "<html><b>Alyssa</b></html>"
     }
 }

--- a/src/test/kotlin/dartzee/game/state/TestTeamParticipant.kt
+++ b/src/test/kotlin/dartzee/game/state/TestTeamParticipant.kt
@@ -37,8 +37,23 @@ class TestTeamParticipant: AbstractTest()
         val teamOne = TeamParticipant(insertTeam(), listOf(pt1, pt2))
         val teamTwo = TeamParticipant(insertTeam(), listOf(pt2, pt1))
 
-        teamOne.getParticipantName().value shouldBe "Alyssa & Leah"
-        teamTwo.getParticipantName().value shouldBe "Leah & Alyssa"
+        teamOne.getParticipantNameHtml(false) shouldBe "<html>Alyssa &#38; Leah</html>"
+        teamTwo.getParticipantNameHtml(false) shouldBe "<html>Leah &#38; Alyssa</html>"
+    }
+
+    @Test
+    fun `Should bold the right player when active`()
+    {
+        val p1 = insertPlayer(name = "Alyssa")
+        val p2 = insertPlayer(name = "Leah")
+
+        val pt1 = insertParticipant(playerId = p1.rowId)
+        val pt2 = insertParticipant(playerId = p2.rowId)
+
+        val team = TeamParticipant(insertTeam(), listOf(pt1, pt2))
+
+        team.getParticipantNameHtml(true, pt1) shouldBe "<html><b>Alyssa</b> &#38; Leah</html>"
+        team.getParticipantNameHtml(true, pt2) shouldBe "<html>Alyssa &#38; <b>Leah</b></html>"
     }
 
     @Test

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -1,16 +1,30 @@
 package dartzee.helper
 
-import dartzee.`object`.SegmentType
 import dartzee.achievements.AchievementType
 import dartzee.ai.DartsAiModel
 import dartzee.core.util.DateStatics
 import dartzee.core.util.FileUtil
 import dartzee.core.util.getSqlDateNow
 import dartzee.dartzee.DartzeeRuleCalculationResult
-import dartzee.db.*
+import dartzee.db.AchievementEntity
+import dartzee.db.DartEntity
+import dartzee.db.DartsMatchEntity
+import dartzee.db.DartzeeRoundResultEntity
+import dartzee.db.DartzeeRuleEntity
+import dartzee.db.DartzeeTemplateEntity
+import dartzee.db.DatabaseMigrator
+import dartzee.db.DeletionAuditEntity
+import dartzee.db.EntityName
+import dartzee.db.GameEntity
+import dartzee.db.ParticipantEntity
+import dartzee.db.PlayerEntity
+import dartzee.db.PlayerImageEntity
+import dartzee.db.TeamEntity
+import dartzee.db.X01FinishEntity
 import dartzee.game.GameType
 import dartzee.game.MatchMode
 import dartzee.logging.LoggingCode
+import dartzee.`object`.SegmentType
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings.databaseDirectory
 import dartzee.utils.InjectedThings.mainDatabase
@@ -119,12 +133,11 @@ fun insertFinishForPlayer(player: PlayerEntity, finish: Int, dtCreation: Timesta
 
 fun insertParticipant(uuid: String = randomGuid(),
                       gameId: String = randomGuid(),
-                      playerId: String = randomGuid(),
+                      playerId: String = insertPlayer().rowId,
                       ordinal: Int = 1,
                       finishingPosition: Int = -1,
                       finalScore: Int = -1,
                       dtFinished: Timestamp = DateStatics.END_OF_TIME,
-                      insertPlayer: Boolean = false,
                       teamId: String = "",
                       database: Database = mainDatabase): ParticipantEntity
 {
@@ -137,11 +150,6 @@ fun insertParticipant(uuid: String = randomGuid(),
     pe.finalScore = finalScore
     pe.dtFinished = dtFinished
     pe.teamId = teamId
-
-    if (insertPlayer)
-    {
-        pe.playerId = insertPlayer().rowId
-    }
 
     pe.saveToDatabase()
 

--- a/src/test/kotlin/dartzee/screen/game/GameTestFactory.kt
+++ b/src/test/kotlin/dartzee/screen/game/GameTestFactory.kt
@@ -25,7 +25,7 @@ import dartzee.screen.game.x01.GameStatisticsPanelX01
 
 fun makeSingleParticipant(player: PlayerEntity, gameId: String? = null) =
     makeSingleParticipant(insertParticipant(playerId = player.rowId, gameId = gameId ?: insertGame().rowId))
-fun makeSingleParticipant(pt: ParticipantEntity = insertParticipant(insertPlayer = true)) = SingleParticipant(pt)
+fun makeSingleParticipant(pt: ParticipantEntity = insertParticipant()) = SingleParticipant(pt)
 
 fun makeTeam(vararg players: PlayerEntity, gameId: String = randomGuid()): TeamParticipant
 {

--- a/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
@@ -9,7 +9,12 @@ import dartzee.db.GameEntity
 import dartzee.db.PlayerImageEntity
 import dartzee.game.loadParticipants
 import dartzee.game.state.X01PlayerState
-import dartzee.helper.*
+import dartzee.helper.AbstractTest
+import dartzee.helper.insertDartsMatch
+import dartzee.helper.insertGame
+import dartzee.helper.insertParticipant
+import dartzee.helper.insertPlayer
+import dartzee.helper.makeX01PlayerState
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.x01.GamePanelX01
 import dartzee.screen.game.x01.MatchStatisticsPanelX01
@@ -167,8 +172,8 @@ class TestDartsMatchScreen: AbstractTest()
         gameTwo.dartsMatchId shouldBe match.rowId
 
         val participants = loadParticipants(gameTwo.rowId)
-        participants[0].getParticipantName().toString() shouldBe "Billie"
-        participants[1].getParticipantName().toString() shouldBe "Amy"
+        participants[0].getParticipantNameHtml(false) shouldBe "<html>Billie</html>"
+        participants[1].getParticipantNameHtml(false) shouldBe "<html>Amy</html>"
     }
 
     private fun setUpMatchScreen(

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
@@ -52,6 +52,8 @@ import dartzee.utils.insertDartzeeRules
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotlintest.matchers.string.shouldContain
+import io.kotlintest.matchers.string.shouldNotContain
 import io.kotlintest.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -59,7 +61,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
 import org.junit.jupiter.api.Test
-import java.awt.Color
 
 class TestGamePanelDartzee: AbstractTest()
 {
@@ -409,16 +410,16 @@ class TestGamePanelDartzee: AbstractTest()
 
         panel.scorerSelected(panel.scorersOrdered[0])
         panel.currentPlayerNumber shouldBe 0
-        panel.scorersOrdered[0].lblName.foreground shouldBe Color.RED
-        panel.scorersOrdered[1].lblName.foreground shouldBe Color.BLACK
+        panel.scorersOrdered[0].lblName.text shouldContain "<b>"
+        panel.scorersOrdered[1].lblName.text shouldNotContain "<b>"
         verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
 
         clearAllMocks()
 
         panel.scorerSelected(panel.scorersOrdered[1])
         panel.currentPlayerNumber shouldBe 1
-        panel.scorersOrdered[0].lblName.foreground shouldBe Color.BLACK
-        panel.scorersOrdered[1].lblName.foreground shouldBe Color.RED
+        panel.scorersOrdered[0].lblName.text shouldNotContain "<b>"
+        panel.scorersOrdered[1].lblName.text shouldContain "<b>"
         verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
     }
 
@@ -620,14 +621,14 @@ class TestGamePanelDartzee: AbstractTest()
 
     private fun DartzeeRuleCarousel.getDisplayedTiles() = tilePanel.getAllChildComponentsForType<DartzeeRuleTile>().filter { it.isVisible }
 
-    private fun setUpDartzeeGameOnDatabase(rounds: Int, player: PlayerEntity? = null, results: List<DartzeeRoundResult> = ruleResults): GameEntity
+    private fun setUpDartzeeGameOnDatabase(rounds: Int, player: PlayerEntity = insertPlayer(), results: List<DartzeeRoundResult> = ruleResults): GameEntity
     {
         val dtFinish = if (rounds > 4) getSqlDateNow() else DateStatics.END_OF_TIME
         val game = insertGame(gameType = GameType.DARTZEE, dtFinish = dtFinish)
 
         insertDartzeeRules(game.rowId, testRules)
 
-        val participant = insertParticipant(gameId = game.rowId, ordinal = 0, playerId = player?.rowId ?: "")
+        val participant = insertParticipant(gameId = game.rowId, ordinal = 0, playerId = player.rowId)
 
         if (rounds > 0)
         {

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
@@ -627,7 +627,7 @@ class TestGamePanelDartzee: AbstractTest()
 
         insertDartzeeRules(game.rowId, testRules)
 
-        val participant = insertParticipant(insertPlayer = (player == null), gameId = game.rowId, ordinal = 0, playerId = player?.rowId ?: "")
+        val participant = insertParticipant(gameId = game.rowId, ordinal = 0, playerId = player?.rowId ?: "")
 
         if (rounds > 0)
         {

--- a/src/test/kotlin/dartzee/screen/game/TestPanelWithScorers.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestPanelWithScorers.kt
@@ -6,6 +6,7 @@ import dartzee.helper.insertPlayer
 import dartzee.screen.game.scorer.AbstractScorer
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 import javax.swing.JFrame
@@ -72,9 +73,9 @@ class TestPanelWithScorers: AbstractTest()
         scrn.assignScorer(makeSingleParticipant(insertPlayer(name = "Player Two")))
         scrn.assignScorer(makeSingleParticipant(insertPlayer(name = "Player Three")))
 
-        scrn.getScorer(0).lblName.text shouldBe "Player One"
-        scrn.getScorer(1).lblName.text shouldBe "Player Two"
-        scrn.getScorer(2).lblName.text shouldBe "Player Three"
+        scrn.getScorer(0).lblName.text shouldContain "Player One"
+        scrn.getScorer(1).lblName.text shouldContain "Player Two"
+        scrn.getScorer(2).lblName.text shouldContain "Player Three"
     }
 
     inner class FakeScorer(participant: IWrappedParticipant) : AbstractScorer(participant)

--- a/src/test/kotlin/dartzee/screen/game/scorer/ScorerTestHelpers.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/ScorerTestHelpers.kt
@@ -1,11 +1,11 @@
 package dartzee.screen.game.scorer
 
 import com.github.alexburlton.swingtest.clickChild
-import com.github.alexburlton.swingtest.findChild
 import com.github.alexburlton.swingtest.getChild
 import dartzee.core.bean.SwingLabel
 import javax.swing.JButton
 
-fun AbstractDartsScorer<*>.getAchievementOverlay() = findChild<AbstractDartsScorer<*>.AchievementOverlay>()
-fun AbstractDartsScorer<*>.AchievementOverlay.getAchievementName() = getChild<SwingLabel> { it.testId == "achievementName" }.text
-fun AbstractDartsScorer<*>.AchievementOverlay.close() = clickChild<JButton>("X")
+fun AbstractDartsScorer<*>.getAchievementOverlay() = getChild<AchievementOverlay>()
+fun AchievementOverlay.getAchievementName(): String = getChild<SwingLabel> { it.testId == "achievementName" }.text
+fun AchievementOverlay.getPlayerName(): String = getChild<SwingLabel> { it.testId == "playerName"}.text
+fun AchievementOverlay.close() = clickChild<JButton>("X")

--- a/src/test/kotlin/dartzee/screen/game/scorer/ScorerTestHelpers.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/ScorerTestHelpers.kt
@@ -1,10 +1,12 @@
 package dartzee.screen.game.scorer
 
 import com.github.alexburlton.swingtest.clickChild
+import com.github.alexburlton.swingtest.findChild
 import com.github.alexburlton.swingtest.getChild
 import dartzee.core.bean.SwingLabel
 import javax.swing.JButton
 
+fun AbstractDartsScorer<*>.findAchievementOverlay() = findChild<AchievementOverlay>()
 fun AbstractDartsScorer<*>.getAchievementOverlay() = getChild<AchievementOverlay>()
 fun AchievementOverlay.getAchievementName(): String = getChild<SwingLabel> { it.testId == "achievementName" }.text
 fun AchievementOverlay.getPlayerName(): String = getChild<SwingLabel> { it.testId == "playerName"}.text

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
@@ -107,7 +107,7 @@ class TestAbstractDartsScorer: AbstractTest()
         thirdAchievement.getAchievementName() shouldBe achievementOne.name
         thirdAchievement.close()
 
-        scorer.getAchievementOverlay() shouldBe null
+        scorer.findAchievementOverlay() shouldBe null
     }
 
     @Test

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
@@ -15,7 +15,6 @@ import dartzee.utils.DartsColour
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
-import java.awt.Color
 
 class TestAbstractDartsScorer: AbstractTest()
 {
@@ -52,18 +51,18 @@ class TestAbstractDartsScorer: AbstractTest()
     }
 
     @Test
-    fun `Should correctly update colours when selected and deselected`()
+    fun `Should correctly update bold text when selected and deselected`()
     {
         val scorer = TestDartsScorer()
         scorer.init()
 
-        val state = TestPlayerState(insertParticipant(), isActive = false)
+        val state = TestPlayerState(insertParticipant(insertPlayer = true), isActive = false)
         scorer.stateChanged(state)
-        scorer.lblName.foreground shouldBe Color.BLACK
+        scorer.lblName.text shouldBe "<html>Clive</html>"
 
         state.updateActive(true)
         scorer.stateChanged(state)
-        scorer.lblName.foreground shouldBe Color.RED
+        scorer.lblName.text shouldBe "<html><b>Clive</b></html>"
     }
 
     @Test

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
@@ -8,8 +8,10 @@ import dartzee.game.state.TestPlayerState
 import dartzee.getRows
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertParticipant
+import dartzee.helper.preparePlayers
 import dartzee.`object`.Dart
 import dartzee.screen.game.makeSingleParticipant
+import dartzee.screen.game.makeTeam
 import dartzee.shouldHaveColours
 import dartzee.utils.DartsColour
 import io.kotlintest.matchers.collections.shouldContainExactly
@@ -56,7 +58,7 @@ class TestAbstractDartsScorer: AbstractTest()
         val scorer = TestDartsScorer()
         scorer.init()
 
-        val state = TestPlayerState(insertParticipant(insertPlayer = true), isActive = false)
+        val state = TestPlayerState(insertParticipant(), isActive = false)
         scorer.stateChanged(state)
         scorer.lblName.text shouldBe "<html>Clive</html>"
 
@@ -70,7 +72,7 @@ class TestAbstractDartsScorer: AbstractTest()
     {
         val state = TestPlayerState(insertParticipant(finishingPosition = -1), scoreSoFar = -1)
 
-        val scorer = TestDartsScorer()
+        val scorer = TestDartsScorer(state.wrappedParticipant)
         scorer.init()
 
         val startingColours = Pair(scorer.lblResult.background, scorer.lblResult.foreground)
@@ -89,23 +91,42 @@ class TestAbstractDartsScorer: AbstractTest()
         val achievementTwo = AchievementX01BestFinish().also { it.attainedValue = 97 }
         val achievementThree = AchievementX01GamesWon().also { it.attainedValue = 1 }
 
-        scorer.achievementUnlocked(achievementOne)
-        scorer.achievementUnlocked(achievementTwo)
-        scorer.achievementUnlocked(achievementThree)
+        scorer.achievementUnlocked(achievementOne, "")
+        scorer.achievementUnlocked(achievementTwo, "")
+        scorer.achievementUnlocked(achievementThree, "")
 
-        val visibleAchievement = scorer.getAchievementOverlay()!!
+        val visibleAchievement = scorer.getAchievementOverlay()
         visibleAchievement.getAchievementName() shouldBe achievementThree.name
         visibleAchievement.close()
 
-        val secondAchievement = scorer.getAchievementOverlay()!!
+        val secondAchievement = scorer.getAchievementOverlay()
         secondAchievement.getAchievementName() shouldBe achievementTwo.name
         secondAchievement.close()
 
-        val thirdAchievement = scorer.getAchievementOverlay()!!
+        val thirdAchievement = scorer.getAchievementOverlay()
         thirdAchievement.getAchievementName() shouldBe achievementOne.name
         thirdAchievement.close()
 
         scorer.getAchievementOverlay() shouldBe null
+    }
+
+    @Test
+    fun `Should pass player name when achievement unlocked for a team`()
+    {
+        val (alice, bob) = preparePlayers(2)
+        val team = makeTeam(alice, bob)
+
+        val scorer = TestDartsScorer(team)
+        scorer.init()
+
+        val achievementOne = AchievementX01BestGame().also { it.attainedValue = 30 }
+        val achievementTwo = AchievementX01BestFinish().also { it.attainedValue = 97 }
+
+        scorer.achievementUnlocked(achievementOne, alice.rowId)
+        scorer.getAchievementOverlay().getPlayerName() shouldBe "Alice"
+
+        scorer.achievementUnlocked(achievementTwo, bob.rowId)
+        scorer.getAchievementOverlay().getPlayerName() shouldBe "Bob"
     }
 
     private class TestDartsScorer(participant: IWrappedParticipant = makeSingleParticipant()) : AbstractDartsScorer<TestPlayerState>(participant)

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractScorer.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractScorer.kt
@@ -6,6 +6,7 @@ import dartzee.helper.AbstractTest
 import dartzee.helper.insertPlayer
 import dartzee.screen.game.makeSingleParticipant
 import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 
@@ -19,7 +20,7 @@ class TestAbstractScorer: AbstractTest()
         val scorer = TestScorer(participant)
         scorer.init()
 
-        scorer.lblName.text shouldBe "Bob"
+        scorer.lblName.text shouldContain "Bob"
         scorer.lblAvatar.icon shouldBe player.getAvatar()
         scorer.panelAvatar.shouldBeVisible()
         scorer.playerIds.shouldContainExactly(player.rowId)

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestDartsScorerRoundTheClock.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestDartsScorerRoundTheClock.kt
@@ -116,10 +116,10 @@ class TestDartsScorerRoundTheClock: AbstractTest()
     fun `Should add back the scorecard when achievement popup is dismissed`()
     {
         val scorer = factoryScorer(inOrder = false)
-        scorer.achievementUnlocked(AchievementClockBestGame())
+        scorer.achievementUnlocked(AchievementClockBestGame(), "")
 
         scorer.findChild<RoundTheClockScorecard>().shouldBeNull()
-        scorer.getAchievementOverlay()!!.close()
+        scorer.getAchievementOverlay().close()
         scorer.findChild<RoundTheClockScorecard>().shouldNotBeNull()
     }
 

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestDartsScorerX01.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestDartsScorerX01.kt
@@ -118,7 +118,7 @@ class TestDartsScorerX01: AbstractTest()
     @Test
     fun `Should toggle checkout suggestions on pause`()
     {
-        val participant = insertParticipant(finishingPosition = 4, dtFinished = DateStatics.END_OF_TIME, insertPlayer = true)
+        val participant = insertParticipant(finishingPosition = 4, dtFinished = DateStatics.END_OF_TIME)
         val state = makeX01PlayerStateWithRounds(101, participant = participant, isActive = true)
 
         val scorer = factoryScorer(participant)
@@ -140,7 +140,7 @@ class TestDartsScorerX01: AbstractTest()
         scorer.tableScores.rowCount shouldBe 0
     }
 
-    private fun factoryScorer(participant: ParticipantEntity = insertParticipant(insertPlayer = true)): DartsScorerX01
+    private fun factoryScorer(participant: ParticipantEntity = insertParticipant()): DartsScorerX01
     {
         val scorer = DartsScorerX01(mockk(relaxed = true), "501", SingleParticipant(participant))
         scorer.init()

--- a/src/test/kotlin/e2e/GameHelpers.kt
+++ b/src/test/kotlin/e2e/GameHelpers.kt
@@ -58,7 +58,7 @@ fun AbstractDartsGameScreen.toggleStats()
 
 fun AbstractDartsGameScreen.getScorer(playerName: String): DartsScorerX01
 {
-    return getChild { it.playerName == playerName }
+    return getChild { it.playerName.contains(playerName) }
 }
 
 data class TwoPlayers(val winner: PlayerEntity, val loser: PlayerEntity)

--- a/src/test/kotlin/e2e/TestMatchE2E.kt
+++ b/src/test/kotlin/e2e/TestMatchE2E.kt
@@ -1,13 +1,13 @@
 package e2e
 
-import com.github.alexburlton.swingtest.getChild
-import dartzee.game.GameLauncher
 import com.github.alexburlton.swingtest.awaitCondition
+import com.github.alexburlton.swingtest.getChild
 import dartzee.core.util.DateStatics
 import dartzee.db.GameEntity
 import dartzee.db.ParticipantEntity
 import dartzee.db.PlayerEntity
 import dartzee.game.GameLaunchParams
+import dartzee.game.GameLauncher
 import dartzee.game.GameType
 import dartzee.game.MatchMode
 import dartzee.helper.AbstractRegistryTest
@@ -97,10 +97,10 @@ class TestMatchE2E: AbstractRegistryTest()
         matchScreen.title shouldBe "Match #1 (First to 2 - 501)"
 
         val summaryPanel = matchScreen.getChild<MatchSummaryPanel<*>>()
-        val winnerScorer = summaryPanel.getChild<MatchScorer> { it.playerName == "Winner" }
+        val winnerScorer = summaryPanel.getChild<MatchScorer> { it.playerName.contains("Winner") }
         winnerScorer.lblResult.text shouldBe "2"
 
-        val loserScorer = summaryPanel.getChild<MatchScorer> { it.playerName == "Loser" }
+        val loserScorer = summaryPanel.getChild<MatchScorer> { it.playerName.contains("Loser") }
         loserScorer.lblResult.text shouldBe "0"
 
         // Select the first game


### PR DESCRIPTION
Makes the following tweaks:

 - Improve padding around player/team names
 - Ditch red colouring for active, instead using **bold** text. For teams, only makes the thrower's name bold
 - In team games, include the player name in achievement popups

![image](https://user-images.githubusercontent.com/5732536/182041466-85a83240-cfd0-48d1-bc4e-b96d23411d0c.png)
