### PR TITLE
Fix Dartzee NPE in aim calculation

### DIFF
--- a/src/main/kotlin/dartzee/dartzee/DartzeeAimCalculator.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeAimCalculator.kt
@@ -21,8 +21,8 @@ class DartzeeAimCalculator
 
     fun getPointToAimFor(dartboard: Dartboard, segmentStatus: SegmentStatus, aggressive: Boolean): Point
     {
-        val scoringSegments = segmentStatus.scoringSegments.map { miniDartboard.getSegment(it.score, it.type)!! }
-        val validSegments = segmentStatus.validSegments.map { miniDartboard.getSegment(it.score, it.type)!! }
+        val scoringSegments = segmentStatus.scoringSegments.map { miniDartboard.getSegment(it.score, it.type)!! }.filter { !it.isMiss() }
+        val validSegments = segmentStatus.validSegments.map { miniDartboard.getSegment(it.score, it.type)!! }.filter { !it.isMiss() }
 
         val segmentsToConsiderAimingFor = if (aggressive && scoringSegments.isNotEmpty()) scoringSegments else validSegments
         if (segmentsToConsiderAimingFor.isEmpty())

--- a/src/test/kotlin/dartzee/dartzee/TestDartzeeAimCalculator.kt
+++ b/src/test/kotlin/dartzee/dartzee/TestDartzeeAimCalculator.kt
@@ -1,10 +1,11 @@
 package dartzee.dartzee
 
 import com.github.alexburlton.swingtest.shouldMatchImage
-import dartzee.`object`.DEFAULT_COLOUR_WRAPPER
 import dartzee.ai.DELIBERATE_MISS
 import dartzee.dartzee.dart.DartzeeDartRuleOdd
 import dartzee.helper.AbstractTest
+import dartzee.missTwenty
+import dartzee.`object`.DEFAULT_COLOUR_WRAPPER
 import dartzee.screen.Dartboard
 import dartzee.screen.dartzee.DartzeeDartboard
 import dartzee.screen.game.dartzee.SegmentStatus
@@ -14,7 +15,11 @@ import io.kotlintest.matchers.numerics.shouldBeLessThan
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import java.awt.*
+import java.awt.BasicStroke
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Graphics2D
+import java.awt.Point
 import javax.swing.ImageIcon
 import javax.swing.JLabel
 
@@ -101,6 +106,19 @@ class TestDartzeeAimCalculator: AbstractTest()
     fun `Should deliberately miss if no valid segments`()
     {
         val segmentStatus = SegmentStatus(emptyList(), emptyList())
+
+        val dartboard = DartzeeDartboard(400, 400)
+        dartboard.paintDartboard(DEFAULT_COLOUR_WRAPPER)
+        dartboard.refreshValidSegments(segmentStatus)
+
+        val pt = calculator.getPointToAimFor(dartboard, segmentStatus, true)
+        pt shouldBe DELIBERATE_MISS
+    }
+
+    @Test
+    fun `Should deliberately miss if only valid segments are misses`()
+    {
+        val segmentStatus = SegmentStatus(listOf(missTwenty), listOf(missTwenty))
 
         val dartboard = DartzeeDartboard(400, 400)
         dartboard.paintDartboard(DEFAULT_COLOUR_WRAPPER)


### PR DESCRIPTION
Fix for this error, which we saw when playing Bruce Forsyth with the `Inside Number Nine` template.

Similar to an edge case that was already addressed, although in this case it was game-breaking!

```
java.lang.NullPointerException
	at dartzee.dartzee.DartzeeAimCalculator.getPointToAimFor(DartzeeAimCalculator.kt:52)
	at dartzee.ai.DartsAiModel.throwDartzeeDart(DartsAiModel.kt:111)
	at dartzee.screen.game.dartzee.GamePanelDartzee.computeAiDart(GamePanelDartzee.kt:53)
	at dartzee.screen.game.DartsGamePanel$DelayedOpponentTurn.run(DartsGamePanel.kt:736)
	at java.base/java.lang.Thread.run(Thread.java:833)
```