### PR TITLE
Less verbose test logging

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,29 +5,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: 11
       - name: Verify tests
         run: |
           sh scripts/verify-test-files.sh
       - name: Build & Unit Test
-        uses: GabrielBB/xvfb-action@v1.0
+        uses: GabrielBB/xvfb-action@v1.6
         with:
           run: ./gradlew koverReport -x integrationAndE2E -x test -x updateScreenshots
       - name: Export test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: unit-test-results
           path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/unitTest/**/*.html
       - name: Export coverage stats
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: kover-report
           path: /home/runner/work/Dartzee/Dartzee/build/reports/kover/html
       - name: Export snapshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failed-snapshots
@@ -45,9 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: 11
       - name: Integration & E2E
         uses: GabrielBB/xvfb-action@v1.0
@@ -57,7 +59,7 @@ jobs:
         with:
           run: ./gradlew integrationAndE2E --info
       - name: Export test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: integration-and-e2e-results
           path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/integrationAndE2E/**/*.html
@@ -65,9 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: 11
       - name: Build JAR
         run: ./gradlew jar --info

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build & Unit Test
         uses: GabrielBB/xvfb-action@v1.0
         with:
-          run: ./gradlew koverReport -x integrationAndE2E -x test -x updateScreenshots --info
+          run: ./gradlew koverReport -x integrationAndE2E -x test -x updateScreenshots
       - name: Export test results
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: 11
       - name: Build JAR
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ tasks.withType(Test) {
     maxHeapSize = "512m"
 
     testLogging {
-        events "failed"
+        events "failed", "standardError"
         exceptionFormat "full"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,16 @@ test {
             '-Dcom.sun.management.jmxremote.ssl=false',
             '-Djava.rmi.server.hostname=localhost',
             '-DscreenshotOs=linux'
+}
 
+tasks.withType(Test) {
     minHeapSize = "512m"
     maxHeapSize = "512m"
+
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
 }
 
 task runDev(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ tasks.withType(Test) {
     maxHeapSize = "512m"
 
     testLogging {
-        events "failed", "standardError"
+        events "failed"
         exceptionFormat "full"
     }
 }

--- a/src/test/kotlin/dartzee/db/TestGameEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestGameEntity.kt
@@ -40,7 +40,7 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
         val sqle = ex.sqlException
         sqle.message shouldContain "duplicate key"
 
-        getCountFromTable("Game") shouldBe 2
+        getCountFromTable("Game") shouldBe 1
     }
 
     @Test

--- a/src/test/kotlin/dartzee/db/TestGameEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestGameEntity.kt
@@ -4,7 +4,11 @@ import dartzee.core.util.DateStatics
 import dartzee.core.util.getSqlDateNow
 import dartzee.game.GameLaunchParams
 import dartzee.game.GameType
-import dartzee.helper.*
+import dartzee.helper.getCountFromTable
+import dartzee.helper.insertGame
+import dartzee.helper.insertPlayerForGame
+import dartzee.helper.randomGuid
+import dartzee.helper.usingInMemoryDatabase
 import dartzee.logging.CODE_SQL_EXCEPTION
 import dartzee.logging.exceptions.WrappedSqlException
 import dartzee.utils.InjectedThings.mainDatabase
@@ -36,7 +40,7 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
         val sqle = ex.sqlException
         sqle.message shouldContain "duplicate key"
 
-        getCountFromTable("Game") shouldBe 1
+        getCountFromTable("Game") shouldBe 2
     }
 
     @Test

--- a/src/test/kotlin/dartzee/screen/TestAboutDialog.kt
+++ b/src/test/kotlin/dartzee/screen/TestAboutDialog.kt
@@ -20,7 +20,7 @@ class TestAboutDialog: AbstractTest()
         val dlg = AboutDialog()
         dlg.isVisible = true
 
-        val lbl = dlg.getChild<JLabel> { it.text.contains("zzChange Log") }
+        val lbl = dlg.getChild<JLabel> { it.text.contains("Change Log") }
         lbl.doClick()
 
         dlg.isVisible shouldBe false

--- a/src/test/kotlin/dartzee/screen/TestAboutDialog.kt
+++ b/src/test/kotlin/dartzee/screen/TestAboutDialog.kt
@@ -20,7 +20,7 @@ class TestAboutDialog: AbstractTest()
         val dlg = AboutDialog()
         dlg.isVisible = true
 
-        val lbl = dlg.getChild<JLabel> { it.text.contains("Change Log") }
+        val lbl = dlg.getChild<JLabel> { it.text.contains("zzChange Log") }
         lbl.doClick()
 
         dlg.isVisible shouldBe false


### PR DESCRIPTION
Disables all the verbose standard out logging in CI when running tests. Unfortunately, this means not getting standard out for tests that fail (which might be useful in some cases, e.g. to see what SQL was run etc). But I can't find a way to get both, so I think this is the best middle ground :shrug: 