### PR TITLE
Fix X01 score breakdown

### DIFF
--- a/src/main/kotlin/dartzee/core/obj/HashMapList.kt
+++ b/src/main/kotlin/dartzee/core/obj/HashMapList.kt
@@ -3,32 +3,13 @@ package dartzee.core.obj
 
 class HashMapList<K: Comparable<K>, V> : HashMap<K, MutableList<V>>()
 {
-    fun getFlattenedValuesSortedByKey(): List<V>
-    {
-        val sortedEntries = entries.sortedBy { it.key }
+    fun getFlattenedValuesSortedByKey() = entries.sortedBy { it.key }.flatMap { it.value }
 
-        val values = mutableListOf<V>()
-        sortedEntries.forEach {
-            values.addAll(it.value)
-        }
-
-        return values
-    }
-
-    fun getAllValues(): MutableList<V>
-    {
-        return values.flatten().toMutableList()
-    }
+    fun getAllValues() = values.flatten().toList()
 
     fun putInList(key: K, value: V)
     {
-        var list: MutableList<V>? = get(key)
-        if (list == null)
-        {
-            list = mutableListOf()
-            put(key, list)
-        }
-
+        val list = getOrPut(key, ::mutableListOf)
         list.add(value)
     }
 }

--- a/src/main/kotlin/dartzee/screen/game/x01/GameStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/x01/GameStatisticsPanelX01.kt
@@ -1,12 +1,12 @@
 package dartzee.screen.game.x01
 
-import dartzee.`object`.Dart
 import dartzee.core.bean.NumberField
 import dartzee.core.util.MathsUtil
 import dartzee.core.util.maxOrZero
 import dartzee.core.util.minOrZero
 import dartzee.game.UniqueParticipantName
 import dartzee.game.state.X01PlayerState
+import dartzee.`object`.Dart
 import dartzee.screen.game.AbstractGameStatisticsPanel
 import dartzee.utils.calculateThreeDartAverage
 import dartzee.utils.getScoringDarts
@@ -175,7 +175,7 @@ open class GameStatisticsPanelX01(gameParams: String): AbstractGameStatisticsPan
         return rounds.filter { it.last().startingScore > nfSetupThreshold.getNumber() }.toList()
     }
 
-    private fun getScoringDarts(playerName: UniqueParticipantName): MutableList<Dart>
+    private fun getScoringDarts(playerName: UniqueParticipantName): List<Dart>
     {
         val darts = getFlattenedDarts(playerName)
         return getScoringDarts(darts, nfSetupThreshold.getNumber())

--- a/src/main/kotlin/dartzee/screen/stats/player/PlayerStatisticsScreen.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/PlayerStatisticsScreen.kt
@@ -1,10 +1,10 @@
 package dartzee.screen.stats.player
 
-import dartzee.`object`.Dart
-import dartzee.`object`.SegmentType
 import dartzee.core.util.getAllChildComponentsForType
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType
+import dartzee.`object`.Dart
+import dartzee.`object`.SegmentType
 import dartzee.screen.EmbeddedScreen
 import dartzee.screen.PlayerSelectDialog
 import dartzee.screen.ScreenCache
@@ -13,10 +13,14 @@ import dartzee.screen.stats.player.golf.StatisticsTabGolfHoleBreakdown
 import dartzee.screen.stats.player.golf.StatisticsTabGolfOptimalScorecard
 import dartzee.screen.stats.player.golf.StatisticsTabGolfScorecards
 import dartzee.screen.stats.player.rtc.StatisticsTabRoundTheClockHitRate
-import dartzee.screen.stats.player.x01.*
+import dartzee.screen.stats.player.x01.StatisticsTabFinishBreakdown
+import dartzee.screen.stats.player.x01.StatisticsTabX01CheckoutPercent
+import dartzee.screen.stats.player.x01.StatisticsTabX01ThreeDartAverage
+import dartzee.screen.stats.player.x01.StatisticsTabX01ThreeDartScores
+import dartzee.screen.stats.player.x01.StatisticsTabX01TopFinishes
 import dartzee.stats.GameWrapper
-import dartzee.utils.InjectedThings.mainDatabase
 import dartzee.utils.InjectedThings.logger
+import dartzee.utils.InjectedThings.mainDatabase
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.event.ActionEvent
@@ -192,7 +196,7 @@ class PlayerStatisticsScreen : EmbeddedScreen()
                     dart.ordinal = ordinal
                     dart.startingScore = startingScore
                     dart.roundNumber = roundNumber
-                    wrapper.addDart(roundNumber, dart)
+                    wrapper.addDart(dart)
                 }
             }
         }

--- a/src/main/kotlin/dartzee/utils/X01Util.kt
+++ b/src/main/kotlin/dartzee/utils/X01Util.kt
@@ -79,11 +79,11 @@ fun isFinishRound(round: List<Dart>): Boolean
 /**
  * Refactored out of GameWrapper for use in game stats panel
  */
-fun getScoringDarts(allDarts: List<Dart>?, scoreCutOff: Int): MutableList<Dart>
+fun getScoringDarts(allDarts: List<Dart>?, scoreCutOff: Int): List<Dart>
 {
-    allDarts ?: return mutableListOf()
+    allDarts ?: return emptyList()
 
-    return allDarts.filter { it.startingScore > scoreCutOff }.toMutableList()
+    return allDarts.filter { it.startingScore > scoreCutOff }.toList()
 }
 
 fun getScoringRounds(dartRounds: List<List<Dart>>, scoreCutOff: Int): List<List<Dart>>

--- a/src/test/kotlin/dartzee/core/obj/TestHashMapList.kt
+++ b/src/test/kotlin/dartzee/core/obj/TestHashMapList.kt
@@ -30,7 +30,7 @@ class TestHashMapList: AbstractTest()
     }
 
     @Test
-    fun `Should return all values across differeny keys`()
+    fun `Should return all values across different keys`()
     {
         val hm = HashMapList<Int, String>()
 

--- a/src/test/kotlin/dartzee/helper/TestFactory.kt
+++ b/src/test/kotlin/dartzee/helper/TestFactory.kt
@@ -78,10 +78,11 @@ fun makeX01RoundsMap(startingScore: Int = 501, vararg darts: List<Dart>): HashMa
 fun makeX01Rounds(startingScore: Int = 501, vararg darts: List<Dart>): List<List<Dart>>
 {
     var currentScore = startingScore
-    darts.forEach {
+    darts.forEachIndexed { ix, it ->
         var roundScore = currentScore
         it.forEach { dart ->
             dart.startingScore = roundScore
+            dart.roundNumber = ix + 1
             roundScore -= dart.getTotal()
         }
 
@@ -173,6 +174,6 @@ fun makeGolfGameWrapper(
     score shouldBe expectedScore
 
     val wrapper = makeGameWrapper(localId = localId, gameParams = gameParams, finalScore = score, dtStart = dtStart)
-    golfRounds.flatten().forEach { wrapper.addDart(it.roundNumber, it) }
+    golfRounds.flatten().forEach(wrapper::addDart)
     return wrapper
 }

--- a/src/test/kotlin/dartzee/helper/X01TestConstants.kt
+++ b/src/test/kotlin/dartzee/helper/X01TestConstants.kt
@@ -1,0 +1,27 @@
+package dartzee.helper
+
+import dartzee.`object`.Dart
+
+private val gameOneRounds = makeX01Rounds(
+    301,
+    listOf(Dart(20, 3), Dart(20, 2), Dart(20, 1)), // 120 (181)
+    listOf(Dart(20, 1), Dart(5, 1), Dart(20, 1)), // 45   (136)
+    listOf(Dart(20, 1), Dart(20, 1), Dart(20, 1)), // 60   (76)
+    listOf(Dart(12, 3), Dart(20, 2)) // 76 (0)
+)
+val GAME_WRAPPER_301_1 = makeGameWrapper(gameParams = "301", finalScore = 11, localId = 1L).also {
+    gameOneRounds.flatten().forEach(it::addDart)
+}
+
+val gameTwoRounds = makeX01Rounds(
+    301,
+    listOf(Dart(5, 1), Dart(20, 1), Dart(20, 1)), // 45 (256)
+    listOf(Dart(12, 3), Dart(20, 1), Dart(4, 1)), // 60 (196)
+    listOf(Dart(19, 1), Dart(19, 1), Dart(19, 1)), // 57 (139)
+    listOf(Dart(1, 0), Dart(1, 1), Dart(1, 0)), // 1     (138)
+    listOf(Dart(20, 1), Dart(20, 1), Dart(18, 1)), // 58  (80)
+    listOf(Dart(20, 2), Dart(20, 2)) // 80 (0)
+)
+val GAME_WRAPPER_301_2 = makeGameWrapper(gameParams = "301", finalScore = 17, localId = 2L).also {
+    gameTwoRounds.flatten().forEach(it::addDart)
+}

--- a/src/test/kotlin/dartzee/screen/stats/player/x01/TestStatisticsTabX01ThreeDartScores.kt
+++ b/src/test/kotlin/dartzee/screen/stats/player/x01/TestStatisticsTabX01ThreeDartScores.kt
@@ -1,0 +1,81 @@
+package dartzee.screen.stats.player.x01
+
+import com.github.alexburlton.swingtest.findChild
+import com.github.alexburlton.swingtest.getChild
+import dartzee.core.bean.NumberField
+import dartzee.core.bean.ScrollTable
+import dartzee.getRows
+import dartzee.helper.AbstractTest
+import dartzee.helper.GAME_WRAPPER_301_1
+import dartzee.helper.GAME_WRAPPER_301_2
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class TestStatisticsTabX01ThreeDartScores: AbstractTest()
+{
+    @Test
+    fun `Should show correct screen state for individual stats`()
+    {
+        val tab = StatisticsTabX01ThreeDartScores()
+        tab.setFilteredGames(listOf(GAME_WRAPPER_301_1), emptyList())
+        tab.populateStats()
+
+        tab.myScores().shouldNotBeNull()
+        tab.otherScores().shouldBeNull()
+    }
+
+    @Test
+    fun `Should show correct screen state when a comparison is included`()
+    {
+        val tab = StatisticsTabX01ThreeDartScores()
+        tab.setFilteredGames(listOf(GAME_WRAPPER_301_1), listOf(GAME_WRAPPER_301_2))
+        tab.populateStats()
+
+        tab.myScores().shouldNotBeNull()
+        tab.otherScores().shouldNotBeNull()
+    }
+
+    @Test
+    fun `Should respond correctly when threshold is updated`()
+    {
+        val tab = StatisticsTabX01ThreeDartScores()
+        tab.setFilteredGames(listOf(GAME_WRAPPER_301_1, GAME_WRAPPER_301_2), emptyList())
+        tab.populateStats()
+
+        val scores = tab.myScores()!!.getRows().map { it[0] }
+        scores.shouldContainExactlyInAnyOrder(120, 60, 57, 45)
+
+        tab.getChild<NumberField>().value = 62
+        val updatedScores = tab.myScores()!!.getRows().map { it[0] }
+        updatedScores.shouldContainExactlyInAnyOrder(120, 60, 58, 57, 45, 1)
+    }
+
+    @Test
+    fun `Breakdown table should update correctly when rows are selected from the summary`()
+    {
+        val tab = StatisticsTabX01ThreeDartScores()
+        tab.getChild<NumberField>().value = 62
+        tab.setFilteredGames(listOf(GAME_WRAPPER_301_1, GAME_WRAPPER_301_2), emptyList())
+        tab.populateStats()
+
+        val scoresTable = tab.myScores()!!
+        val breakdownTable = tab.myBreakdown()!!
+
+        scoresTable.selectRow(1)
+        breakdownTable.getRows() shouldBe listOf(listOf("20, 20, 5", 2, 1L))
+
+        scoresTable.selectRow(4)
+        breakdownTable.getRows().shouldContainExactly(
+            listOf("20, 20, 20", 1, 1L),
+            listOf("T12, 20, 4", 1, 2L)
+        )
+    }
+
+    private fun StatisticsTabX01ThreeDartScores.myScores() = findChild<ScrollTable> { it.testId == "PlayerScores" }
+    private fun StatisticsTabX01ThreeDartScores.myBreakdown() = findChild<ScrollTable> { it.testId == "PlayerBreakdown" }
+    private fun StatisticsTabX01ThreeDartScores.otherScores() = findChild<ScrollTable> { it.testId == "OtherScores" }
+}

--- a/src/test/kotlin/dartzee/stats/TestGameWrapper.kt
+++ b/src/test/kotlin/dartzee/stats/TestGameWrapper.kt
@@ -1,0 +1,113 @@
+package dartzee.stats
+
+import dartzee.helper.AbstractTest
+import dartzee.helper.makeDart
+import dartzee.helper.makeGameWrapper
+import dartzee.helper.makeX01Rounds
+import dartzee.`object`.Dart
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class TestGameWrapper : AbstractTest()
+{
+    @Test
+    fun `Should capture darts accurately`()
+    {
+        val roundTwo = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1))
+        val rounds = makeX01Rounds(
+            501,
+            listOf(Dart(20, 1), Dart(20, 1), Dart(20, 3)),
+            roundTwo
+        )
+
+        val gameWrapper = makeGameWrapper()
+        rounds.flatten().forEach(gameWrapper::addDart)
+
+        gameWrapper.getDartsForFinalRound() shouldBe roundTwo
+        gameWrapper.getAllDarts().shouldContainExactly(rounds.flatten())
+    }
+
+    @Test
+    fun `Should report three dart average correctly`()
+    {
+        val gameWrapper = makeGameWrapper()
+        gameWrapper.getThreeDartAverage(70) shouldBe -1.0
+
+        val d1 = makeDart(20, 1, startingScore = 100)
+        val d2 = makeDart(20, 2, startingScore = 100)
+        val d3 = makeDart(10, 0, startingScore = 80)
+        val d4 = makeDart(5, 3, startingScore = 100)
+
+        listOf(d1, d2, d3, d4).forEach(gameWrapper::addDart)
+        val result = gameWrapper.getThreeDartAverage(70)
+        result shouldBe 56.25
+    }
+
+    @Test
+    fun `Should return scoring darts correctly based on threshold`()
+    {
+        val round1 = listOf(Dart(20, 3), Dart(20, 1), Dart(5, 1)) // 115
+        val round2 = listOf(Dart(20, 1), Dart(20, 1), Dart(1, 1)) //  74
+        val round3 = listOf(Dart(9, 1), Dart(14, 1), Dart(1, 1))  //  50
+        val rounds = makeX01Rounds(200, round1, round2, round3)
+
+        val wrapper = makeGameWrapper()
+        rounds.flatten().forEach(wrapper::addDart)
+
+        wrapper.getScoringDarts(118).shouldContainExactly(round1)
+        wrapper.getScoringDarts(100).shouldContainExactly(round1 + round2.first())
+    }
+
+    @Test
+    fun `Should populate the three dart score map correctly`()
+    {
+        val gameOneRounds = makeX01Rounds(
+            301,
+            listOf(Dart(20, 3), Dart(20, 2), Dart(20, 1)), // 120 (181)
+            listOf(Dart(20, 1), Dart(5, 1), Dart(20, 1)), // 45   (136)
+            listOf(Dart(20, 1), Dart(20, 1), Dart(20, 1)), // 60   (76)
+            listOf(Dart(12, 3), Dart(20, 2)) // 76 (0)
+        )
+
+        val gameTwoRounds = makeX01Rounds(
+            301,
+            listOf(Dart(5, 1), Dart(20, 1), Dart(20, 1)), // 45 (256)
+            listOf(Dart(12, 3), Dart(20, 1), Dart(4, 1)), // 60 (196)
+            listOf(Dart(19, 1), Dart(19, 1), Dart(19, 1)), // 57 (139)
+            listOf(Dart(1, 0), Dart(1, 1), Dart(1, 0)), // 1     (138)
+            listOf(Dart(20, 1), Dart(20, 1), Dart(18, 1)), // 58  (80)
+            listOf(Dart(20, 2), Dart(20, 2)) // 80 (0)
+        )
+
+        val wrapperOne = makeGameWrapper(gameParams = "301", finalScore = 11, localId = 1L)
+        gameOneRounds.flatten().forEach(wrapperOne::addDart)
+
+        val wrapperTwo = makeGameWrapper(gameParams = "301", finalScore = 17, localId = 2L)
+        gameTwoRounds.flatten().forEach(wrapperTwo::addDart)
+
+        // Full map with the lowest threshold possible
+        val map = mutableMapOf<Int, ThreeDartScoreWrapper>()
+        wrapperOne.populateThreeDartScoreMap(map, 62)
+        wrapperTwo.populateThreeDartScoreMap(map, 62)
+
+        map.keys.shouldContainExactlyInAnyOrder(120, 60, 58, 57, 45, 1)
+
+        val fortyFive = map.getValue(45)
+        fortyFive.createRows().shouldContainExactly(arrayOf("20, 20, 5", 2, 1L))
+
+        val sixty = map.getValue(60)
+        sixty.createRows().shouldContainExactly(
+            arrayOf("20, 20, 20", 1, 1L),
+            arrayOf("T12, 20, 4", 1, 2L)
+        )
+
+        // Higher threshold - test rounds are knocked out
+        val shorterMap = mutableMapOf<Int, ThreeDartScoreWrapper>()
+        wrapperOne.populateThreeDartScoreMap(shorterMap, 140)
+        wrapperTwo.populateThreeDartScoreMap(shorterMap, 140)
+
+        shorterMap.keys.shouldContainExactlyInAnyOrder(120, 60, 57, 45)
+    }
+}

--- a/src/test/kotlin/dartzee/stats/TestGameWrapper.kt
+++ b/src/test/kotlin/dartzee/stats/TestGameWrapper.kt
@@ -1,6 +1,8 @@
 package dartzee.stats
 
 import dartzee.helper.AbstractTest
+import dartzee.helper.GAME_WRAPPER_301_1
+import dartzee.helper.GAME_WRAPPER_301_2
 import dartzee.helper.makeDart
 import dartzee.helper.makeGameWrapper
 import dartzee.helper.makeX01Rounds
@@ -63,34 +65,10 @@ class TestGameWrapper : AbstractTest()
     @Test
     fun `Should populate the three dart score map correctly`()
     {
-        val gameOneRounds = makeX01Rounds(
-            301,
-            listOf(Dart(20, 3), Dart(20, 2), Dart(20, 1)), // 120 (181)
-            listOf(Dart(20, 1), Dart(5, 1), Dart(20, 1)), // 45   (136)
-            listOf(Dart(20, 1), Dart(20, 1), Dart(20, 1)), // 60   (76)
-            listOf(Dart(12, 3), Dart(20, 2)) // 76 (0)
-        )
-
-        val gameTwoRounds = makeX01Rounds(
-            301,
-            listOf(Dart(5, 1), Dart(20, 1), Dart(20, 1)), // 45 (256)
-            listOf(Dart(12, 3), Dart(20, 1), Dart(4, 1)), // 60 (196)
-            listOf(Dart(19, 1), Dart(19, 1), Dart(19, 1)), // 57 (139)
-            listOf(Dart(1, 0), Dart(1, 1), Dart(1, 0)), // 1     (138)
-            listOf(Dart(20, 1), Dart(20, 1), Dart(18, 1)), // 58  (80)
-            listOf(Dart(20, 2), Dart(20, 2)) // 80 (0)
-        )
-
-        val wrapperOne = makeGameWrapper(gameParams = "301", finalScore = 11, localId = 1L)
-        gameOneRounds.flatten().forEach(wrapperOne::addDart)
-
-        val wrapperTwo = makeGameWrapper(gameParams = "301", finalScore = 17, localId = 2L)
-        gameTwoRounds.flatten().forEach(wrapperTwo::addDart)
-
         // Full map with the lowest threshold possible
         val map = mutableMapOf<Int, ThreeDartScoreWrapper>()
-        wrapperOne.populateThreeDartScoreMap(map, 62)
-        wrapperTwo.populateThreeDartScoreMap(map, 62)
+        GAME_WRAPPER_301_1.populateThreeDartScoreMap(map, 62)
+        GAME_WRAPPER_301_2.populateThreeDartScoreMap(map, 62)
 
         map.keys.shouldContainExactlyInAnyOrder(120, 60, 58, 57, 45, 1)
 
@@ -105,8 +83,8 @@ class TestGameWrapper : AbstractTest()
 
         // Higher threshold - test rounds are knocked out
         val shorterMap = mutableMapOf<Int, ThreeDartScoreWrapper>()
-        wrapperOne.populateThreeDartScoreMap(shorterMap, 140)
-        wrapperTwo.populateThreeDartScoreMap(shorterMap, 140)
+        GAME_WRAPPER_301_1.populateThreeDartScoreMap(shorterMap, 140)
+        GAME_WRAPPER_301_2.populateThreeDartScoreMap(shorterMap, 140)
 
         shorterMap.keys.shouldContainExactlyInAnyOrder(120, 60, 57, 45)
     }

--- a/src/test/kotlin/dartzee/utils/TestX01Util.kt
+++ b/src/test/kotlin/dartzee/utils/TestX01Util.kt
@@ -105,12 +105,9 @@ class TestX01Util: AbstractTest()
     @Test
     fun testGetScoringDarts()
     {
-        val d1 = Dart(20, 1)
-        val d2 = Dart(20, 1)
-        val d3 = Dart(20, 1)
-        d1.startingScore = 51
-        d2.startingScore = 50
-        d3.startingScore = 49
+        val d1 = makeDart(1, 1, startingScore = 51)
+        val d2 = makeDart(1, 1, startingScore = 50)
+        val d3 = makeDart(20, 1, startingScore = 49)
 
         val list = mutableListOf(d1, d2, d3)
 
@@ -136,17 +133,12 @@ class TestX01Util: AbstractTest()
     @Test
     fun testCalculateThreeDartAverage()
     {
-        val d1 = Dart(20, 1)
-        val d2 = Dart(20, 2)
-        val d3 = Dart(10, 0)
-        val d4 = Dart(5, 3)
+        val d1 = makeDart(20, 1, startingScore = 100)
+        val d2 = makeDart(20, 2, startingScore = 100)
+        val d3 = makeDart(10, 0, startingScore = 80)
+        val d4 = makeDart(5, 3, startingScore = 100)
 
-        d1.startingScore = 100
-        d2.startingScore = 100
-        d3.startingScore = 80
-        d4.startingScore = 100
-
-        val list = mutableListOf(d1, d2, d3, d4)
+        val list = listOf(d1, d2, d3, d4)
         val result = calculateThreeDartAverage(list, 70)
         val resultTwo = calculateThreeDartAverage(list, 90) //The miss should be excluded
         val resultThree = calculateThreeDartAverage(list, 200) //Test an empty list

--- a/src/test/kotlin/dartzee/utils/TestX01Util.kt
+++ b/src/test/kotlin/dartzee/utils/TestX01Util.kt
@@ -3,11 +3,13 @@ package dartzee.utils
 import dartzee.helper.AbstractTest
 import dartzee.helper.makeDart
 import dartzee.helper.makeDartsModel
+import dartzee.helper.makeX01Rounds
 import dartzee.`object`.Dart
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
@@ -114,6 +116,21 @@ class TestX01Util: AbstractTest()
 
         val result = getScoringDarts(list, 50)
         result.shouldContainExactly(d1)
+    }
+
+    @Test
+    fun `getScoringRounds should exclude rounds correctly`()
+    {
+        val round1 = listOf(Dart(20, 3), Dart(20, 1), Dart(5, 1)) // 115
+        val round2 = listOf(Dart(20, 1), Dart(20, 1), Dart(1, 1)) //  74
+        val round3 = listOf(Dart(9, 1), Dart(14, 1), Dart(1, 1))  //  50
+        val rounds = makeX01Rounds(200, round1, round2, round3)
+
+        getScoringRounds(rounds, 200).shouldBeEmpty()
+        getScoringRounds(rounds, 75).shouldContainExactlyInAnyOrder(listOf(round1))
+        getScoringRounds(rounds, 74).shouldContainExactlyInAnyOrder(round1, round2)
+        getScoringRounds(rounds, 51).shouldContainExactlyInAnyOrder(round1, round2)
+        getScoringRounds(rounds, 50).shouldContainExactlyInAnyOrder(round1, round2, round3)
     }
 
     @Test


### PR DESCRIPTION
Ditch janky custom logic that was needlessly recalculating `startingScore`, without taking teams into account. Also add some tests around the X01 `GameWrapper` methods