### PR TITLE
Fix overly sensitive data loss check

### DIFF
--- a/src/main/kotlin/dartzee/db/DeletionAuditEntity.kt
+++ b/src/main/kotlin/dartzee/db/DeletionAuditEntity.kt
@@ -32,18 +32,18 @@ class DeletionAuditEntity(database: Database = mainDatabase): AbstractEntity<Del
 
     companion object
     {
-        fun factory(entity: AbstractEntity<*>): DeletionAuditEntity
+        fun factory(entity: AbstractEntity<*>, database: Database = mainDatabase): DeletionAuditEntity
         {
-            val result = DeletionAuditEntity()
+            val result = DeletionAuditEntity(database)
             result.assignRowId()
             result.entityName = entity.getTableName()
             result.entityId = entity.rowId
             return result
         }
 
-        fun factoryAndSave(entity: AbstractEntity<*>): DeletionAuditEntity
+        fun factoryAndSave(entity: AbstractEntity<*>, database: Database = mainDatabase): DeletionAuditEntity
         {
-            return factory(entity).also { it.saveToDatabase() }
+            return factory(entity, database).also { it.saveToDatabase() }
         }
     }
 }


### PR DESCRIPTION
This check was added back when the sync stuff didn't properly support deletion of data, so needed tweaking a bit. Replication was:

 - Play a game on Device A, and sync it.
 - Pull on Device B. Delete the game and sync the changes.
 - Perform a sync from Device A. It freaks out because the game has gone walkabouts.

I quite like having this sanity check still, so I've just added logic to take into account data in `DeletionAudit`.