### PR TITLE
More dependency bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,10 @@ repositories {
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20'
     implementation 'org.apache.commons:commons-math3:3.6.1'
-    implementation 'com.miglayout:miglayout-swing:5.2'
+    implementation 'com.miglayout:miglayout-swing:11.0'
     implementation 'org.jfree:jfreechart:1.5.4'
     implementation 'com.mashape.unirest:unirest-java:1.4.9'
-    implementation 'com.github.lgooddatepicker:LGoodDatePicker:10.3.1'
+    implementation 'com.github.lgooddatepicker:LGoodDatePicker:11.2.1'
     implementation 'org.apache.derby:derby:10.14.2.0'
     implementation 'com.amazonaws:aws-java-sdk-elasticsearch:1.12.396'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.396'


### PR DESCRIPTION
Bumps MigLayout and LGoodDatePicker. Quickly smoke tested screens using these and they looked fine.

No idea why the MigLayout releases jump suddenly from 5.3 to 11, can't see any release notes :shrug: . Seems others are confused too!: https://github.com/mikaelgrev/miglayout/issues/89