### PR TITLE
Fix pause race condition

### DIFF
--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -550,7 +550,7 @@ abstract class DartsGamePanel<S : AbstractDartsScorer<PlayerState>, D: Dartboard
             // If we've been told to pause then we're going to do a reset and not save anything
             if (!shouldAiStopThrowing())
             {
-                SwingUtilities.invokeLater { confirmRound() }
+                confirmRound()
             }
         }
     }


### PR DESCRIPTION
Trello: https://trello.com/c/kaoe7Zga/237-nosuchelementexception-when-pausing-the-ai

Definitely fixes the NPE, which I could replicate. I guess it might potentially introduce Swing noise instead, but hopefully not.