### PR TITLE
Restrict dartboard width

### DIFF
--- a/src/main/kotlin/dartzee/screen/Dartboard.kt
+++ b/src/main/kotlin/dartzee/screen/Dartboard.kt
@@ -114,7 +114,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
         stopListening()
         hmSegmentKeyToSegment.clear()
 
-        val width = width
+        val boardWidth = minOf(width, height)
         val height = height
 
         val timer = DurationTimer()
@@ -124,7 +124,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
         //Initialise/clear down variables
         this.colourWrapper = colourWrapper
         centerPoint = Point(width / 2, height / 2)
-        diameter = 0.7 * width
+        diameter = 0.7 * boardWidth
 
         //Construct the segments, populated with their points. Cache pt -> segment.
         getPointList(width, height).forEach { factoryAndCacheSegmentForPoint(it) }


### PR DESCRIPTION
Prevents the dartboard overflowing over the top/bottom of the screen when it's very wide and not very high. In general, the dartboard is now always fully within bounds and centered, regardless of the size of the game window.