### PR TITLE
Bug fix release

### DIFF
--- a/src/main/kotlin/dartzee/screen/game/AbstractDartsGameScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/AbstractDartsGameScreen.kt
@@ -11,7 +11,7 @@ import javax.swing.WindowConstants
 abstract class AbstractDartsGameScreen : FocusableWindow(), WindowListener
 {
     var haveLostFocus = false
-    private var havePacked = false
+    protected var shouldPack = true
 
     init
     {
@@ -39,10 +39,9 @@ abstract class AbstractDartsGameScreen : FocusableWindow(), WindowListener
     }
     fun packIfNecessary()
     {
-        if (!havePacked)
+        if (shouldPack)
         {
             pack()
-            havePacked = true
         }
     }
 

--- a/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
@@ -77,6 +77,8 @@ abstract class DartsMatchScreen<PlayerState: AbstractPlayerState<PlayerState>>(
             return
         }
 
+        shouldPack = false
+
         val firstGamePanel = hmGameIdToTab.values.first()
         val firstGameParticipants = firstGamePanel.getPlayerStates().map { it.wrappedParticipant }
 

--- a/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
+++ b/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
@@ -1,5 +1,5 @@
 package dartzee.utils
 
-const val DARTS_VERSION_NUMBER = "v6.0.2"
+const val DARTS_VERSION_NUMBER = "v6.0.3"
 const val DARTZEE_REPOSITORY_URL = "https://api.github.com/repos/alyssaburlton/Dartzee"
 const val DARTZEE_MANUAL_DOWNLOAD_URL = "https://github.com/alyssaburlton/Dartzee/releases"

--- a/src/main/resources/ChangeLog
+++ b/src/main/resources/ChangeLog
@@ -1,3 +1,13 @@
+--------- v6.0.3 ---------
+
+= Fixed a bug where pausing an AI player could sometimes cause the app to freeze
+= Fixed issue where match screens would revert to the default size whenever a new game was launched
+= Fixed dartboard rendering so it always remains in the bounds of the window
+= Fixed a couple of other benign error logs
+= Small tweaks to box and whisker plot rendering
+= Bumped dependency versions
+= 88.2% test coverage (11917 / 13505 lines covered by 2172 tests)
+
 --------- v6.0.2 ---------
 
 = Fixed a bug that prevented syncing when a game had been deleted

--- a/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
@@ -178,16 +178,22 @@ class TestDartsMatchScreen: AbstractTest()
     }
 
     @Test
-    fun `Should not repack the screen after the first time`()
+    fun `Should not repack the screen when a new game is launched`()
     {
+        val p1 = insertPlayer(name = "Amy")
+        val p2 = insertPlayer(name = "Billie")
+        val gameOneStates = listOf(p1, p2).map { makeX01PlayerState(player = it) }
+
         val match = insertDartsMatch(gameParams = "501")
 
         val scrn = setUpMatchScreen(match = match)
-        scrn.packIfNecessary()
+        val firstGame = insertGame(dartsMatchId = match.rowId, matchOrdinal = 1)
 
-        // Player changes to their desired size...
+        val firstPanel = scrn.addGameToMatchOnEdt(firstGame)
+        every { firstPanel.getPlayerStates() } returns gameOneStates
         scrn.size = Dimension(1000, 1000)
-        scrn.packIfNecessary()
+
+        scrn.startNextGameIfNecessaryOnEdt()
         scrn.size.shouldBe(Dimension(1000, 1000))
     }
 
@@ -210,6 +216,7 @@ private class FakeMatchScreen(match: DartsMatchEntity,
         val panel = mockk<GamePanelX01>(relaxed = true)
         every { panel.gameEntity } returns game
         every { panel.gameTitle } returns "${game.localId}"
+        every { panel.startNewGame(any()) } answers { parent.packIfNecessary() }
         return panel
     }
 


### PR DESCRIPTION
Tweaked the fix for [this issue](https://trello.com/c/MNK1IKoI/241-match-window-resets-to-default-size-whenever-a-new-game-gets-launched), as I noticed that loaded matches with several games had weird looking dartboards. We'll now only stop packing at the point where the first new game gets launched, so loading code is unchanged from before.

Also change log etc for a release to get all the bug fixes etc out :smile: 