### PR TITLE
Dartboard refactor 7

### DIFF
--- a/src/main/kotlin/dartzee/bean/DartLabel.kt
+++ b/src/main/kotlin/dartzee/bean/DartLabel.kt
@@ -1,0 +1,12 @@
+package dartzee.bean
+
+import dartzee.utils.ResourceCache
+import javax.swing.JLabel
+
+class DartLabel : JLabel(ResourceCache.DART_IMG)
+{
+    init
+    {
+        setSize(76, 80)
+    }
+}

--- a/src/main/kotlin/dartzee/bean/InteractiveDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/InteractiveDartboard.kt
@@ -4,36 +4,44 @@ import dartzee.core.util.getParentWindow
 import dartzee.`object`.ColourWrapper
 import dartzee.`object`.DartboardSegment
 import dartzee.utils.getColourWrapperFromPrefs
-import java.awt.Graphics
-import java.awt.Graphics2D
+import dartzee.utils.getHighlightedColour
 import java.awt.Point
 import java.awt.event.MouseEvent
 import java.awt.event.MouseMotionListener
 
 class InteractiveDartboard(colourWrapper: ColourWrapper = getColourWrapperFromPrefs()) : PresentationDartboard(colourWrapper, true), MouseMotionListener
 {
-    private var lastHoveredSegment: DartboardSegment? = null
+    private var hoveredSegment: DartboardSegment? = null
 
     init
     {
         addMouseMotionListener(this)
     }
 
-    fun highlightDartboard(pt: Point, customGraphics: Graphics? = null)
+    fun highlightDartboard(pt: Point)
     {
-        val hoveredSegment = getSegmentForPoint(pt)
-        if (hoveredSegment == lastHoveredSegment)
+        val newHoveredSegment = getSegmentForPoint(pt)
+        if (hoveredSegment == newHoveredSegment)
         {
             //Nothing to do
             return
         }
 
-        val graphics = customGraphics as? Graphics2D ?: graphics as Graphics2D
+        hoveredSegment?.let(::revertOverriddenSegmentColour)
 
-        lastHoveredSegment?.let { paintSegment(it, graphics, false) }
+        if (newHoveredSegment.isMiss())
+        {
+            hoveredSegment = null
+        }
+        else
+        {
+            hoveredSegment = newHoveredSegment
+            overrideSegmentColour(newHoveredSegment, getHighlightedColour(colourWrapper.getColour(newHoveredSegment)))
+        }
 
-        lastHoveredSegment = hoveredSegment
-        paintSegment(hoveredSegment, graphics, true)
+        if (!newHoveredSegment.isMiss()) {
+            overrideSegmentColour(newHoveredSegment, getHighlightedColour(colourWrapper.getColour(newHoveredSegment)))
+        }
     }
 
     override fun mouseMoved(arg0: MouseEvent)

--- a/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
@@ -12,7 +12,6 @@ import dartzee.utils.getAnglesForScore
 import dartzee.utils.getColourFromHashMap
 import dartzee.utils.getColourWrapperFromPrefs
 import dartzee.utils.getFontForDartboardLabels
-import dartzee.utils.getHighlightedColour
 import dartzee.utils.getNeighbours
 import dartzee.utils.translatePoint
 import java.awt.Color
@@ -21,17 +20,20 @@ import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.Point
 import java.awt.RenderingHints
+import java.awt.image.BufferedImage
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.SwingConstants
 import kotlin.math.roundToInt
 
 open class PresentationDartboard(
-    private val colourWrapper: ColourWrapper = getColourWrapperFromPrefs(),
+    protected val colourWrapper: ColourWrapper = getColourWrapperFromPrefs(),
     private val renderScoreLabels: Boolean = false
 ) : JComponent(), IDartboard
 {
     private val overriddenSegmentColours = mutableMapOf<DartboardSegment, Color>()
+    private val dirtySegments = mutableListOf<DartboardSegment>()
+    private var lastPaintImage: BufferedImage? = null
 
     override fun computeRadius() = computeRadius(width, height)
     override fun computeCenter() = Point(width / 2, height / 2)
@@ -69,41 +71,53 @@ open class PresentationDartboard(
     {
         super.paintComponent(g)
 
-        val graphics2D = g as Graphics2D
-        paintOuterBoard(graphics2D)
-        getAllPossibleSegments().forEach { paintSegment(it, graphics2D) }
-        paintScoreLabels(graphics2D)
+        if (lastPaintImage != null && lastPaintImage?.width == width && lastPaintImage?.height == height && dirtySegments.isNotEmpty()) {
+            dirtySegments.forEach { paintSegment(it, lastPaintImage!!) }
+            dirtySegments.clear()
+            g.drawImage(lastPaintImage!!, 0, 0, this)
+        } else {
+            val bi = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+            val biGraphics = bi.createGraphics()
+            paintOuterBoard(biGraphics)
+            getAllPossibleSegments().forEach { paintSegment(it, bi) }
+            paintScoreLabels(biGraphics)
+
+            g.drawImage(bi, 0, 0, this)
+            lastPaintImage = bi
+        }
     }
 
-    protected fun paintSegment(segment: DartboardSegment, graphics: Graphics2D, highlight: Boolean = false)
+    private fun paintSegment(segment: DartboardSegment, bi: BufferedImage)
     {
         val colour = overriddenSegmentColours[segment] ?: getColourFromHashMap(segment, colourWrapper)
-        val hoveredColour = if (highlight) getHighlightedColour(colour) else colour
-
-        colourSegment(segment, hoveredColour, graphics)
+        colourSegment(segment, colour, bi)
     }
 
     fun overrideSegmentColour(segment: DartboardSegment, colour: Color)
     {
         overriddenSegmentColours[segment] = colour
+        dirtySegments.add(segment)
 
-        if (graphics != null) {
-            colourSegment(segment, colour)
-        }
+        repaint()
     }
 
-    private fun colourSegment(segment: DartboardSegment, color: Color?, customGraphics: Graphics2D? = null)
+    fun revertOverriddenSegmentColour(segment: DartboardSegment)
+    {
+        overriddenSegmentColours.remove(segment)
+        dirtySegments.add(segment)
+
+        repaint()
+    }
+
+    private fun colourSegment(segment: DartboardSegment, color: Color, bi: BufferedImage)
     {
         val pts = getPointsForSegment(segment)
         val edgePts = computeEdgePoints(pts)
 
-        val graphics = customGraphics ?: graphics as Graphics2D
-        graphics.paint = color
-        pts.forEach { graphics.drawLine(it.x, it.y, it.x, it.y) }
+        pts.forEach { bi.setRGB(it.x, it.y, color.rgb) }
 
-        if (colourWrapper.edgeColour != null) {
-            graphics.paint = colourWrapper.edgeColour
-            edgePts.forEach { graphics.drawLine(it.x, it.y, it.x, it.y) }
+        colourWrapper.edgeColour?.let { edgeColour ->
+            edgePts.forEach { bi.setRGB(it.x, it.y, edgeColour.rgb) }
         }
     }
 

--- a/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
@@ -28,8 +28,7 @@ import kotlin.math.roundToInt
 
 open class PresentationDartboard(
     private val colourWrapper: ColourWrapper = getColourWrapperFromPrefs(),
-    private val renderScoreLabels: Boolean = false,
-    private val scoreLabelColour: Color = Color.WHITE
+    private val renderScoreLabels: Boolean = false
 ) : JComponent(), IDartboard
 {
     private val overriddenSegmentColours = mutableMapOf<DartboardSegment, Color>()
@@ -135,7 +134,7 @@ open class PresentationDartboard(
     {
         //Create a label with standard properties
         val lbl = JLabel(score.toString())
-        lbl.foreground = scoreLabelColour
+        lbl.foreground = Color.WHITE
         lbl.horizontalAlignment = SwingConstants.CENTER
         lbl.font = fontToUse
 

--- a/src/main/kotlin/dartzee/object/ColourWrapper.kt
+++ b/src/main/kotlin/dartzee/object/ColourWrapper.kt
@@ -37,11 +37,17 @@ class ColourWrapper(private var evenSingleColour : Color, private var evenDouble
             1 -> outerBullColour
             else -> innerBullColour
         }
-
     }
+
+    fun getColour(segment: DartboardSegment) = getColour(segment.getMultiplier(), segment.score)
 
     fun getColour(multiplier: Int, score: Int): Color
     {
+        if (score == 25)
+        {
+            return getBullColour(multiplier)
+        }
+
         val even = hmScoreToOrdinal[Integer.valueOf(score)] ?: false
         return when (multiplier)
         {

--- a/src/main/kotlin/dartzee/object/ComputationalDartboard.kt
+++ b/src/main/kotlin/dartzee/object/ComputationalDartboard.kt
@@ -2,7 +2,6 @@ package dartzee.`object`
 
 import dartzee.utils.UPPER_BOUND_OUTSIDE_BOARD_RATIO
 import dartzee.utils.getAllNonMissSegments
-import dartzee.utils.getAngleForPoint
 import dartzee.utils.getAverage
 import dartzee.utils.getPotentialAimPoints
 import dartzee.utils.translatePoint
@@ -29,12 +28,4 @@ class ComputationalDartboard(private val width: Int, private val height: Int): I
             val pt = getAverage(getPointsForSegment(it))
             toComputedPoint(pt)
         }
-
-    fun toComputedPoint(pt: Point): ComputedPoint {
-        val segment = getSegmentForPoint(pt)
-        val distance = pt.distance(computeCenter()) / computeRadius()
-        val angle = getAngleForPoint(pt, computeCenter())
-
-        return ComputedPoint(pt, segment, distance, angle)
-    }
 }

--- a/src/main/kotlin/dartzee/object/IDartboard.kt
+++ b/src/main/kotlin/dartzee/object/IDartboard.kt
@@ -3,6 +3,7 @@ package dartzee.`object`
 import dartzee.utils.AimPoint
 import dartzee.utils.computePointsForSegment
 import dartzee.utils.factorySegmentForPoint
+import dartzee.utils.getAngleForPoint
 import java.awt.Point
 
 interface IDartboard
@@ -17,4 +18,12 @@ interface IDartboard
     fun getSegmentForPoint(pt: Point) = factorySegmentForPoint(pt, computeCenter(), computeRadius() * 2)
 
     fun translateAimPoint(aimPoint: AimPoint) = AimPoint(computeCenter(), computeRadius(), aimPoint.angle, aimPoint.ratio).point
+
+    fun toComputedPoint(pt: Point): ComputedPoint {
+        val segment = getSegmentForPoint(pt)
+        val distance = pt.distance(computeCenter()) / computeRadius()
+        val angle = getAngleForPoint(pt, computeCenter())
+
+        return ComputedPoint(pt, segment, distance, angle)
+    }
 }

--- a/src/main/kotlin/dartzee/screen/Dartboard.kt
+++ b/src/main/kotlin/dartzee/screen/Dartboard.kt
@@ -17,6 +17,7 @@ import dartzee.screen.game.DartsGameScreen
 import dartzee.utils.AimPoint
 import dartzee.utils.DurationTimer
 import dartzee.utils.InjectedThings.logger
+import dartzee.utils.ResourceCache
 import dartzee.utils.UPPER_BOUND_OUTSIDE_BOARD_RATIO
 import dartzee.utils.convertForDestinationDartboard
 import dartzee.utils.factoryFontMetrics
@@ -391,7 +392,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
         {
             for (i in 0..4)
             {
-                val lbl = JLabel(DARTIMG)
+                val lbl = JLabel(ResourceCache.DART_IMG)
                 lbl.setSize(76, 80)
                 lbl.isVisible = false
                 add(lbl)
@@ -457,9 +458,4 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
     override fun mouseDragged(arg0: MouseEvent) {}
     override fun mouseEntered(arg0: MouseEvent) {}
     override fun mouseExited(arg0: MouseEvent) {}
-
-    companion object
-    {
-        private val DARTIMG = ImageIcon(Dartboard::class.java.getResource("/dartImage.png"))
-    }
 }

--- a/src/main/kotlin/dartzee/screen/DartsApp.kt
+++ b/src/main/kotlin/dartzee/screen/DartsApp.kt
@@ -1,6 +1,5 @@
 package dartzee.screen
 
-import dartzee.`object`.DartsClient
 import dartzee.achievements.convertEmptyAchievements
 import dartzee.core.bean.AbstractDevScreen
 import dartzee.core.bean.CheatBar
@@ -11,6 +10,7 @@ import dartzee.logging.CODE_SCREEN_LOAD_ERROR
 import dartzee.logging.KEY_CURRENT_SCREEN
 import dartzee.logging.LoggingCode
 import dartzee.main.exitApplication
+import dartzee.`object`.DartsClient
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.DevUtilities
 import dartzee.utils.InjectedThings
@@ -21,9 +21,18 @@ import dartzee.utils.ResourceCache
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.Image
-import java.awt.event.*
+import java.awt.event.ActionEvent
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import java.awt.event.WindowEvent
+import java.awt.event.WindowListener
 import java.util.*
-import javax.swing.*
+import javax.swing.AbstractAction
+import javax.swing.ImageIcon
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.KeyStroke
+import javax.swing.WindowConstants
 
 private const val CMD_PURGE_GAME = "purge "
 private const val CMD_LOAD_GAME = "load "
@@ -31,6 +40,7 @@ private const val CMD_CLEAR_CONSOLE = "cls"
 private const val CMD_EMPTY_SCREEN_CACHE = "emptyscr"
 private const val CMD_SANITY = "sanity"
 private const val CMD_GUID = "guid"
+private const val CMD_TEST = "test"
 
 class DartsApp(commandBar: CheatBar) : AbstractDevScreen(commandBar), WindowListener
 {
@@ -204,6 +214,11 @@ class DartsApp(commandBar: CheatBar) : AbstractDevScreen(commandBar), WindowList
         else if (cmd == "stacktrace")
         {
             logger.error(LoggingCode("test"), "Testing stack trace")
+        }
+        else if (cmd == CMD_TEST)
+        {
+            val window = TestWindow()
+            window.isVisible = true
         }
 
         return textToShow

--- a/src/main/kotlin/dartzee/screen/GameplayDartboard.kt
+++ b/src/main/kotlin/dartzee/screen/GameplayDartboard.kt
@@ -1,0 +1,89 @@
+package dartzee.screen
+
+import dartzee.bean.DartLabel
+import dartzee.bean.InteractiveDartboard
+import dartzee.core.util.getAllChildComponentsForType
+import dartzee.core.util.getParentWindow
+import dartzee.core.util.runOnEventThreadBlocking
+import dartzee.`object`.ComputedPoint
+import dartzee.screen.game.DartsGameScreen
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import java.awt.event.MouseEvent
+import java.awt.event.MouseListener
+import javax.swing.JLayeredPane
+
+class GameplayDartboard : JLayeredPane(), MouseListener
+{
+    private val dartboard = InteractiveDartboard()
+    private val dartsThrown = mutableListOf<ComputedPoint>()
+
+    init
+    {
+        isOpaque = false
+        add(dartboard, Integer.valueOf(-1))
+
+        dartboard.addMouseListener(this)
+
+        addComponentListener(object : ComponentAdapter() {
+            override fun componentResized(evt: ComponentEvent) = resized()
+        })
+    }
+
+    private fun resized()
+    {
+        dartboard.setBounds(0, 0, width, height)
+
+        clearDartLabels()
+
+        dartsThrown.forEach(::addDartLabel)
+    }
+
+    fun clearDarts()
+    {
+        dartsThrown.clear()
+        clearDartLabels()
+        repaint()
+    }
+
+    private fun clearDartLabels() = getAllChildComponentsForType<DartLabel>().forEach { remove(it) }
+
+    private fun dartThrown(pt: ComputedPoint)
+    {
+        dartsThrown.add(pt)
+
+        runOnEventThreadBlocking { addDartLabel(pt) }
+    }
+
+    private fun addDartLabel(computedPt: ComputedPoint)
+    {
+        val lbl = DartLabel()
+        lbl.location = dartboard.interpretPoint(computedPt)
+        add(lbl)
+        setLayer(lbl, LAYER_DARTS, 5-dartsThrown.size)
+    }
+
+    override fun mouseReleased(arg0: MouseEvent)
+    {
+        if (!suppressClickForGameWindow())
+        {
+            dartThrown(dartboard.toComputedPoint(arg0.point))
+        }
+    }
+    private fun suppressClickForGameWindow(): Boolean
+    {
+        val scrn = getParentWindow() as? DartsGameScreen ?: return false
+        if (scrn.haveLostFocus)
+        {
+            scrn.haveLostFocus = false
+            return true
+        }
+
+        return false
+    }
+
+    override fun mouseClicked(e: MouseEvent?) {}
+    override fun mousePressed(e: MouseEvent?) {}
+    override fun mouseEntered(e: MouseEvent?) {}
+    override fun mouseExited(e: MouseEvent?) {}
+}

--- a/src/main/kotlin/dartzee/screen/TestWindow.kt
+++ b/src/main/kotlin/dartzee/screen/TestWindow.kt
@@ -12,12 +12,13 @@ class TestWindow : JFrame(), ActionListener
 {
     private val dartboard = GameplayDartboard()
     private val btnClear = JButton("Clear darts")
+    private val btnRepaint = JButton("Repaint dartboard")
 
     init
     {
         contentPane.layout = BorderLayout(0, 0)
-        size = Dimension(400, 400)
-        preferredSize = Dimension(400, 400)
+        size = Dimension(1000, 800)
+        preferredSize = Dimension(1000, 800)
 
         contentPane.add(dartboard, BorderLayout.CENTER)
 
@@ -25,10 +26,16 @@ class TestWindow : JFrame(), ActionListener
         contentPane.add(panelSouth, BorderLayout.SOUTH)
 
         panelSouth.add(btnClear)
+        panelSouth.add(btnRepaint)
+
         btnClear.addActionListener(this)
+        btnRepaint.addActionListener(this)
     }
 
     override fun actionPerformed(e: ActionEvent?) {
-        dartboard.clearDarts()
+        when (e?.source) {
+            btnClear -> dartboard.clearDarts()
+            btnRepaint -> dartboard.repaint()
+        }
     }
 }

--- a/src/main/kotlin/dartzee/screen/TestWindow.kt
+++ b/src/main/kotlin/dartzee/screen/TestWindow.kt
@@ -1,0 +1,34 @@
+package dartzee.screen
+
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.event.ActionEvent
+import java.awt.event.ActionListener
+import javax.swing.JButton
+import javax.swing.JFrame
+import javax.swing.JPanel
+
+class TestWindow : JFrame(), ActionListener
+{
+    private val dartboard = GameplayDartboard()
+    private val btnClear = JButton("Clear darts")
+
+    init
+    {
+        contentPane.layout = BorderLayout(0, 0)
+        size = Dimension(400, 400)
+        preferredSize = Dimension(400, 400)
+
+        contentPane.add(dartboard, BorderLayout.CENTER)
+
+        val panelSouth = JPanel()
+        contentPane.add(panelSouth, BorderLayout.SOUTH)
+
+        panelSouth.add(btnClear)
+        btnClear.addActionListener(this)
+    }
+
+    override fun actionPerformed(e: ActionEvent?) {
+        dartboard.clearDarts()
+    }
+}

--- a/src/main/kotlin/dartzee/utils/ResourceCache.kt
+++ b/src/main/kotlin/dartzee/utils/ResourceCache.kt
@@ -20,6 +20,8 @@ import javax.swing.ImageIcon
  */
 object ResourceCache
 {
+    val DART_IMG = ImageIcon(javaClass.getResource("/dartImage.png"))
+
     val IMG_BRUCE = ImageIcon(javaClass.getResource("/horrific/forsyth.png"))
     val IMG_DEV = ImageIcon(javaClass.getResource("/horrific/dev.png"))
     val IMG_MITCHELL = ImageIcon(javaClass.getResource("/horrific/mitchell.png"))

--- a/src/test/kotlin/dartzee/bean/TestInteractiveDartboard.kt
+++ b/src/test/kotlin/dartzee/bean/TestInteractiveDartboard.kt
@@ -7,9 +7,6 @@ import dartzee.`object`.DartboardSegment
 import dartzee.`object`.SegmentType
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import java.awt.image.BufferedImage
-import javax.swing.ImageIcon
-import javax.swing.JLabel
 
 class TestInteractiveDartboard : AbstractTest()
 {
@@ -17,20 +14,15 @@ class TestInteractiveDartboard : AbstractTest()
     @Tag("screenshot")
     fun `Should match snapshot - hovered`()
     {
-        val img = BufferedImage(400, 400, BufferedImage.TYPE_INT_ARGB)
-
         val dartboard = InteractiveDartboard(DEFAULT_COLOUR_WRAPPER)
         dartboard.setBounds(0, 0, 400, 400)
-        dartboard.paint(img.graphics)
 
         val pt = dartboard.getPointsForSegment(DartboardSegment(SegmentType.OUTER_SINGLE, 1)).first()
-        dartboard.highlightDartboard(pt, img.graphics)
-        img.toLabel().shouldMatchImage("hovered-1")
+        dartboard.highlightDartboard(pt)
+        dartboard.shouldMatchImage("hovered-1")
 
         val pt2 = dartboard.getPointsForSegment(DartboardSegment(SegmentType.DOUBLE, 25)).first()
-        dartboard.highlightDartboard(pt2, img.graphics)
-        img.toLabel().shouldMatchImage("hovered-bull")
+        dartboard.highlightDartboard(pt2)
+        dartboard.shouldMatchImage("hovered-bull")
     }
-
-    private fun BufferedImage.toLabel() = JLabel(ImageIcon(this)).also { it.setSize(width, height) }
 }


### PR DESCRIPTION
WIP to start porting the remaining functionality to a `GameplayDartboard`. 

As part of this, I've revisited some of the earlier stuff. The old way of doing hovering turned out to be problematic - painting directly off of a mouse move event means the `LayoutManager` never gets notified that any painting is happening, which means nothing else rerenders. This is problematic for all the other layers that are supposed to be on top like the darts that have been thrown - hovering ends up painting over the top of these even though the dartboard is at the lowest level.

The fix is to instead capture some state on hover and then call `repaint()` - this fires off all the right LayoutManager stuff and then we can take into account the new state when painting. However, it's obviously wasteful to recompute the entire dartboard every time we hover over a segment, so there's some new logic which takes the previous BufferedImage and tweaks it in `paintComponent` - assuming that the dimensions haven't changed.

It's all a bit messy - and it's sad to have to reintroduce any kind of caching - but it's the only thing I could get to work. Another solution might have been to have a "HoverListener" on the dartboard that could be notified when a hover has happened (and then tell all the other layered stuff to repaint), but I'm not sure this would actually have worked because it would need to avoid inadvertently making the dartboard repaint again *and* it might have resulted in "flickering" where the darts are briefly painted over then appear again. 

This new approach does tidy up a few things - screenshot testing `InteractiveDartboard` has become less torturous and having hovering go via the existing `overrideSegmentColour` stuff is a nice win too.