### PR TITLE
Fix dartboard painting in tests

### DIFF
--- a/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
@@ -73,30 +73,33 @@ open class PresentationDartboard(
 
     override fun paintComponent(g: Graphics)
     {
-        super.paintComponent(g)
-
-        val cachedImage = lastPaintImage
-        if (cachedImage != null && cachedImage.width == width && cachedImage.height == height)
+        synchronized(this)
         {
-            repaintDirtySegments(cachedImage)
-            g.drawImage(cachedImage, 0, 0, this)
-        }
-        else
-        {
-            val timer = DurationTimer()
-            val bi = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-            val biGraphics = bi.createGraphics()
-            paintOuterBoard(biGraphics)
-            getAllPossibleSegments().forEach { paintSegment(it, bi) }
-            paintScoreLabels(biGraphics)
+            super.paintComponent(g)
 
-            g.drawImage(bi, 0, 0, this)
-            lastPaintImage = bi
+            val cachedImage = lastPaintImage
+            if (cachedImage != null && cachedImage.width == width && cachedImage.height == height)
+            {
+                repaintDirtySegments(cachedImage)
+                g.drawImage(cachedImage, 0, 0, this)
+            }
+            else
+            {
+                val timer = DurationTimer()
+                val bi = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+                val biGraphics = bi.createGraphics()
+                paintOuterBoard(biGraphics)
+                getAllPossibleSegments().forEach { paintSegment(it, bi) }
+                paintScoreLabels(biGraphics)
 
-            val duration = timer.getDuration()
-            logger.info(
-                CODE_RENDERED_DARTBOARD, "Rendered dartboard[$width, $height] in ${duration}ms",
-                KEY_DURATION to duration)
+                g.drawImage(bi, 0, 0, this)
+                lastPaintImage = bi
+
+                val duration = timer.getDuration()
+                logger.info(
+                    CODE_RENDERED_DARTBOARD, "Rendered dartboard[$width, $height] in ${duration}ms",
+                    KEY_DURATION to duration)
+            }
         }
     }
 

--- a/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
@@ -1,5 +1,6 @@
 package dartzee.bean
 
+import dartzee.core.util.runOnEventThreadBlocking
 import dartzee.logging.CODE_RENDERED_DARTBOARD
 import dartzee.logging.KEY_DURATION
 import dartzee.`object`.ColourWrapper
@@ -73,8 +74,7 @@ open class PresentationDartboard(
 
     override fun paintComponent(g: Graphics)
     {
-        synchronized(this)
-        {
+        runOnEventThreadBlocking {
             super.paintComponent(g)
 
             val cachedImage = lastPaintImage

--- a/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
@@ -1,6 +1,5 @@
 package dartzee.bean
 
-import dartzee.core.util.runOnEventThreadBlocking
 import dartzee.logging.CODE_RENDERED_DARTBOARD
 import dartzee.logging.KEY_DURATION
 import dartzee.`object`.ColourWrapper
@@ -74,32 +73,30 @@ open class PresentationDartboard(
 
     override fun paintComponent(g: Graphics)
     {
-        runOnEventThreadBlocking {
-            super.paintComponent(g)
+        super.paintComponent(g)
 
-            val cachedImage = lastPaintImage
-            if (cachedImage != null && cachedImage.width == width && cachedImage.height == height)
-            {
-                repaintDirtySegments(cachedImage)
-                g.drawImage(cachedImage, 0, 0, this)
-            }
-            else
-            {
-                val timer = DurationTimer()
-                val bi = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-                val biGraphics = bi.createGraphics()
-                paintOuterBoard(biGraphics)
-                getAllPossibleSegments().forEach { paintSegment(it, bi) }
-                paintScoreLabels(biGraphics)
+        val cachedImage = lastPaintImage
+        if (cachedImage != null && cachedImage.width == width && cachedImage.height == height)
+        {
+            repaintDirtySegments(cachedImage)
+            g.drawImage(cachedImage, 0, 0, this)
+        }
+        else
+        {
+            val timer = DurationTimer()
+            val bi = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+            val biGraphics = bi.createGraphics()
+            paintOuterBoard(biGraphics)
+            getAllPossibleSegments().forEach { paintSegment(it, bi) }
+            paintScoreLabels(biGraphics)
 
-                g.drawImage(bi, 0, 0, this)
-                lastPaintImage = bi
+            g.drawImage(bi, 0, 0, this)
+            lastPaintImage = bi
 
-                val duration = timer.getDuration()
-                logger.info(
-                    CODE_RENDERED_DARTBOARD, "Rendered dartboard[$width, $height] in ${duration}ms",
-                    KEY_DURATION to duration)
-            }
+            val duration = timer.getDuration()
+            logger.info(
+                CODE_RENDERED_DARTBOARD, "Rendered dartboard[$width, $height] in ${duration}ms",
+                KEY_DURATION to duration)
         }
     }
 

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -158,7 +158,10 @@ fun PresentationDartboard.getPointForSegment(segment: DartboardSegment) = getAve
 /**
  * TODO - swing-test should do all the interactions on the event thread
  */
-fun PresentationDartboard.doClick(pt: Point) = runOnEventThreadBlocking {
-    doClick(pt.x, pt.y)
+fun PresentationDartboard.doClick(pt: Point) {
+    runOnEventThreadBlocking {
+        doClick(pt.x, pt.y)
+    }
+
     flushEdt()
 }

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -1,6 +1,7 @@
 package dartzee
 
 import com.github.alyssaburlton.swingtest.doClick
+import com.github.alyssaburlton.swingtest.flushEdt
 import dartzee.bean.ComboBoxGameType
 import dartzee.bean.PresentationDartboard
 import dartzee.core.bean.DateFilterPanel
@@ -159,4 +160,5 @@ fun PresentationDartboard.getPointForSegment(segment: DartboardSegment) = getAve
  */
 fun PresentationDartboard.doClick(pt: Point) = runOnEventThreadBlocking {
     doClick(pt.x, pt.y)
+    flushEdt()
 }


### PR DESCRIPTION
Ensure we paint the `PresentationDartboard` on the EDT, to fix occasional test flakes. Shouldn't have any impact on the app itself, since `paintComponent` is part of internal swing stuff so should only be happening on the EDT anyway. 