### PR TITLE
Fix deadlocked tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   unit-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,7 @@ tasks.withType<Test> {
     }
 
     testLogging {
-        mutableSetOf(TestLogEvent.PASSED, TestLogEvent.FAILED)
+        events = mutableSetOf(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.FAILED)
         exceptionFormat = TestExceptionFormat.FULL
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import kotlinx.kover.api.KoverTaskExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
@@ -134,7 +135,7 @@ tasks.withType<Test> {
     }
 
     testLogging {
-        events("failed")
+        mutableSetOf(TestLogEvent.PASSED, TestLogEvent.FAILED)
         exceptionFormat = TestExceptionFormat.FULL
     }
 }

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -38,6 +38,7 @@ import java.util.*
 import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.table.DefaultTableModel
+import javax.swing.text.JTextComponent
 
 val bullseye = DartboardSegment(SegmentType.DOUBLE, 25)
 val outerBull = DartboardSegment(SegmentType.OUTER_SINGLE, 25)
@@ -176,3 +177,8 @@ fun Container.clickCancel() = clickChild<JButton>(text = "Cancel")
  * TODO - Add to swing-test
  */
 inline fun <reified W : Window> findWindow(fn: (window: W) -> Boolean = { true }): W? = Window.getWindows().find { it is W && fn(it) } as? W
+
+fun JTextComponent.typeText(newText: String)
+{
+    runOnEventThreadBlocking { text = newText }
+}

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -1,6 +1,5 @@
 package dartzee.helper
 
-import com.github.alyssaburlton.swingtest.flushEdt
 import dartzee.core.helper.TestMessageDialogFactory
 import dartzee.core.util.DialogUtil
 import dartzee.logging.LogDestinationSystemOut
@@ -76,12 +75,11 @@ abstract class AbstractTest
         val windows = Window.getWindows()
         if (windows.isNotEmpty())
         {
-            SwingUtilities.invokeLater {
+            SwingUtilities.invokeAndWait {
                 val visibleWindows = windows.filter { it.isVisible }
                 visibleWindows.forEach { it.dispose() }
             }
 
-            flushEdt()
             AppContext.getAppContext().remove(Window::class.java)
         }
 

--- a/src/test/kotlin/dartzee/screen/player/TestPlayerManagementPanel.kt
+++ b/src/test/kotlin/dartzee/screen/player/TestPlayerManagementPanel.kt
@@ -28,6 +28,7 @@ import dartzee.screen.HumanConfigurationDialog
 import dartzee.screen.ScreenCache
 import dartzee.screen.ai.AIConfigurationDialog
 import dartzee.screen.ai.AISimulationSetupDialog
+import dartzee.typeText
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -220,7 +221,7 @@ class TestPlayerManagementPanel: AbstractTest()
         val dlg = findWindow<HumanConfigurationDialog>()
         dlg.shouldNotBeNull()
 
-        dlg.getChild<JTextField>("nameField").text = "New name"
+        dlg.getChild<JTextField>("nameField").typeText("New name")
         dlg.clickOk()
         flushEdt()
 
@@ -239,7 +240,7 @@ class TestPlayerManagementPanel: AbstractTest()
         val dlg = findWindow<AIConfigurationDialog>()
         dlg.shouldNotBeNull()
 
-        dlg.getChild<JTextField>("nameField").text = "New name"
+        dlg.getChild<JTextField>("nameField").typeText("New name")
         dlg.clickOk()
         flushEdt()
 

--- a/src/test/kotlin/dartzee/screen/player/TestPlayerManagementScreen.kt
+++ b/src/test/kotlin/dartzee/screen/player/TestPlayerManagementScreen.kt
@@ -14,6 +14,7 @@ import dartzee.helper.insertPlayer
 import dartzee.helper.randomGuid
 import dartzee.screen.HumanConfigurationDialog
 import dartzee.screen.ai.AIConfigurationDialog
+import dartzee.typeText
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -82,7 +83,7 @@ class TestPlayerManagementScreen: AbstractTest()
         val dlg = findWindow<HumanConfigurationDialog>()
         dlg.shouldNotBeNull()
 
-        dlg.getChild<JTextField>("nameField").text = "Bongo"
+        dlg.getChild<JTextField>("nameField").typeText("Bongo")
         dlg.getChild<PlayerAvatar>().avatarId = randomGuid()
         dlg.clickOk()
         dlg.isVisible shouldBe false
@@ -103,7 +104,7 @@ class TestPlayerManagementScreen: AbstractTest()
         val dlg = findWindow<AIConfigurationDialog>()
         dlg.shouldNotBeNull()
 
-        dlg.getChild<JTextField>("nameField").text = "Bingo"
+        dlg.getChild<JTextField>("nameField").typeText("Bingo")
         dlg.getChild<PlayerAvatar>().avatarId = randomGuid()
         dlg.clickOk()
         dlg.isVisible shouldBe false


### PR DESCRIPTION
Relevant thread stacks were:

```
[threadStack] AWT-EventQueue-0 (WAITING)
	at java.base@11.0.18/java.lang.Object.wait(Native Method)
	at java.base@11.0.18/java.lang.Object.wait(Object.java:328)
	at java.desktop@11.0.18/javax.swing.text.AbstractDocument.readLock(AbstractDocument.java:1398)
	at java.desktop@11.0.18/javax.swing.plaf.basic.BasicTextUI.paint(BasicTextUI.java:914)
	at java.desktop@11.0.18/javax.swing.plaf.synth.SynthTextFieldUI.paint(SynthTextFieldUI.java:197)
	at java.desktop@11.0.18/javax.swing.plaf.synth.SynthTextFieldUI.update(SynthTextFieldUI.java:181)
	at java.desktop@11.0.18/javax.swing.JComponent.paintComponent(JComponent.java:797)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1074)
	at java.desktop@11.0.18/javax.swing.JComponent.paintChildren(JComponent.java:907)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1083)
	at java.desktop@11.0.18/javax.swing.JComponent.paintChildren(JComponent.java:907)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1083)
	at java.desktop@11.0.18/javax.swing.JComponent.paintChildren(JComponent.java:907)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1083)
	at java.desktop@11.0.18/javax.swing.JComponent.paintChildren(JComponent.java:907)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1083)
	at java.desktop@11.0.18/javax.swing.JComponent.paintChildren(JComponent.java:907)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1083)
	at java.desktop@11.0.18/javax.swing.JLayeredPane.paint(JLayeredPane.java:590)
	at java.desktop@11.0.18/javax.swing.JComponent.paintChildren(JComponent.java:907)
	at java.desktop@11.0.18/javax.swing.JComponent.paintToOffscreen(JComponent.java:5262)
	at java.desktop@11.0.18/javax.swing.BufferStrategyPaintManager.paint(BufferStrategyPaintManager.java:246)
	at java.desktop@11.0.18/javax.swing.RepaintManager.paint(RepaintManager.java:1323)
	at java.desktop@11.0.18/javax.swing.JComponent.paint(JComponent.java:1060)
	at java.desktop@11.0.18/java.awt.GraphicsCallback$PaintCallback.run(GraphicsCallback.java:39)
	at java.desktop@11.0.18/sun.awt.SunGraphicsCallback.runOneComponent(SunGraphicsCallback.java:78)
	at java.desktop@11.0.18/sun.awt.SunGraphicsCallback.runComponents(SunGraphicsCallback.java:115)

[threadStack] Test worker (BLOCKED)
	at java.desktop@11.0.18/java.awt.Component.invalidate(Component.java:3010)
	at java.desktop@11.0.18/java.awt.Container.invalidate(Container.java:1614)
	at java.desktop@11.0.18/java.awt.Component.show(Component.java:1699)
	at java.desktop@11.0.18/java.awt.Component.show(Component.java:1716)
	at java.desktop@11.0.18/java.awt.Component.setVisible(Component.java:1663)
	at java.desktop@11.0.18/javax.swing.JComponent.setVisible(JComponent.java:2675)
	at app//dartzee.core.bean.GhostText.toggleVisibility(GhostText.kt:29)
	at app//dartzee.core.bean.GhostText.removeUpdate(GhostText.kt:42)
	at java.desktop@11.0.18/javax.swing.text.AbstractDocument.fireRemoveUpdate(AbstractDocument.java:261)
	at java.desktop@11.0.18/javax.swing.text.AbstractDocument.handleRemove(AbstractDocument.java:628)
	at java.desktop@11.0.18/javax.swing.text.AbstractDocument.remove(AbstractDocument.java:596)
	at java.desktop@11.0.18/javax.swing.text.AbstractDocument.replace(AbstractDocument.java:672)
	at java.desktop@11.0.18/javax.swing.text.JTextComponent.setText(JTextComponent.java:1729)
	at app//dartzee.screen.player.TestPlayerManagementPanel.Should support editing an AI player(TestPlayerManagementPanel.kt:250)
```

So the deadlock, I think, is:

 - Our code instructs the text field to update its text, not on the AWT thread. As part of this, we acquire `AbstractDocument.writeLock()`. This has a knock-on effect of doing some repainting stuff, which tries to acquire a lock on `Component.getTreeLock()`
 - Meanwhile, the dialog we're typing text into is still being painted (it's only just been shown). Someplace in here, we evidently gain a lock on `Component.getTreeLock()` - not sure exactly where. And then we try to paint the BasicTextUI, which wants a lock on `AbstractDocument.writeLock()`, which it can't get as it's being held by the other thread.

Classic deadlock. Solution is to type the text on the EDT - in this case that would ensure all locks are being acquired and released on that thread and so no deadlocking is possible. 