### PR TITLE
Add a default test timeout of 30s

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.timeout.default=30 s


### PR DESCRIPTION
Faster feedback for when tests get stuck due to a Swing deadlock thing.