### PR TITLE
Fix game deletion

### DIFF
--- a/src/main/kotlin/dartzee/core/util/DialogUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/DialogUtil.kt
@@ -24,6 +24,7 @@ object DialogUtil
         dialogFactory = implementation
     }
 
+    @Deprecated("Use showInfo")
     fun showInfoOLD(infoText: String)
     {
         logDialogShown("Info", "Information", infoText)
@@ -45,6 +46,7 @@ object DialogUtil
         logDialogClosed("CustomInfo", null)
     }
 
+    @Deprecated("Use showError")
     fun showErrorOLD(errorText: String)
     {
         dismissLoadingDialogOLD()
@@ -68,6 +70,7 @@ object DialogUtil
         SwingUtilities.invokeLater { showErrorOLD(errorText) }
     }
 
+    @Deprecated("Use showQuestion")
     fun showQuestionOLD(message: String, allowCancel: Boolean = false): Int
     {
         logDialogShown("Question", "Question", message)
@@ -85,6 +88,7 @@ object DialogUtil
         return selection
     }
 
+    @Deprecated("Use showLoadingDialog / dismissLoadingDialog")
     fun showLoadingDialogOLD(text: String)
     {
         logDialogShown("Loading", "", text)
@@ -108,6 +112,7 @@ object DialogUtil
         }
     }
 
+    @Deprecated("Use showLoadingDialog / dismissLoadingDialog")
     fun dismissLoadingDialogOLD()
     {
         val dismissed = dialogFactory.dismissLoading()

--- a/src/main/kotlin/dartzee/db/DartzeeRuleEntity.kt
+++ b/src/main/kotlin/dartzee/db/DartzeeRuleEntity.kt
@@ -2,8 +2,8 @@ package dartzee.db
 
 import dartzee.dartzee.DartzeeRuleCalculationResult
 import dartzee.dartzee.DartzeeRuleDto
-import dartzee.dartzee.parseDartRule
 import dartzee.dartzee.parseAggregateRule
+import dartzee.dartzee.parseDartRule
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings.mainDatabase
 
@@ -61,7 +61,9 @@ class DartzeeRuleEntity(database: Database = mainDatabase): AbstractEntity<Dartz
     fun retrieveForTemplate(templateId: String) = retrieveEntities(getTemplateWhere(templateId)).sortedBy { it.ordinal }
     fun deleteForTemplate(templateId: String) = deleteWhere(getTemplateWhere(templateId))
 
-    fun retrieveForGame(gameId: String) = retrieveEntities("EntityName = 'Game' AND EntityId = '$gameId'").sortedBy { it.ordinal }
+    fun retrieveForGame(gameId: String) = retrieveEntities(getGameWhere(gameId)).sortedBy { it.ordinal }
+    fun deleteForGame(gameId: String) = deleteWhere(getGameWhere(gameId))
 
     private fun getTemplateWhere(templateId: String) = "EntityName = '${EntityName.DartzeeTemplate}' AND EntityId = '$templateId'"
+    private fun getGameWhere(gameId: String) = "EntityName = '${EntityName.Game}' AND EntityId = '$gameId'"
 }

--- a/src/main/kotlin/dartzee/utils/DevUtilities.kt
+++ b/src/main/kotlin/dartzee/utils/DevUtilities.kt
@@ -2,6 +2,8 @@ package dartzee.utils
 
 import dartzee.core.util.DialogUtil
 import dartzee.db.DartEntity
+import dartzee.db.DartzeeRoundResultEntity
+import dartzee.db.DartzeeRuleEntity
 import dartzee.db.GameEntity
 import dartzee.db.IParticipant
 import dartzee.db.ParticipantEntity
@@ -52,23 +54,25 @@ object DevUtilities
         val gameId = GameEntity.getGameId(localId)
         if (gameId == null)
         {
-            DialogUtil.showErrorOLD("No game exists for ID $localId")
+            DialogUtil.showError("No game exists for ID $localId")
             return
         }
 
         val scrn = ScreenCache.getDartsGameScreen(gameId)
         if (scrn != null)
         {
-            DialogUtil.showErrorOLD("Cannot delete a game that's open.")
+            DialogUtil.showError("Cannot delete a game that's open.")
             return
         }
 
         val participants = loadParticipants(gameId)
-        val participantEntities: List<IParticipant> = participants.flatMap { it.individuals + it.participant }
+        val participantEntities: List<IParticipant> = participants.flatMap { it.individuals + it.participant }.distinct()
         val participantIds = participantEntities.filterIsInstance<ParticipantEntity>().map { it.rowId }
         val teamIds = participantEntities.filterIsInstance<TeamEntity>().map { it.rowId }
         val ptSql = participantIds.getQuotedIdStr()
         val dartCount = if (participantIds.isEmpty()) 0 else DartEntity().countWhere("ParticipantId IN $ptSql")
+        val dartzeeRoundResultCount = if (participantIds.isEmpty()) 0 else DartzeeRoundResultEntity().countWhere("ParticipantId IN $ptSql")
+        val dartzeeRules = DartzeeRuleEntity().retrieveForGame(gameId)
 
         val question = """
             Purge all data for Game #$localId? The following rows will be deleted:
@@ -76,22 +80,26 @@ object DevUtilities
             Participant: ${participantIds.size} rows
             Team: ${teamIds.size} rows
             Dart: $dartCount rows
+            DartzeeRoundResult: $dartzeeRoundResultCount rows
+            DartzeeRule: ${dartzeeRules.size} rows
         """.trimIndent()
 
-        val answer = DialogUtil.showQuestionOLD(question, false)
+        val answer = DialogUtil.showQuestion(question, false)
         if (answer == JOptionPane.YES_OPTION)
         {
             if (participantIds.isNotEmpty())
             {
                 DartEntity().deleteWhere("ParticipantId IN $ptSql")
+                DartzeeRoundResultEntity().deleteWhere("ParticipantId IN $ptSql")
             }
 
             TeamEntity().deleteWhere("GameId = '$gameId'")
             ParticipantEntity().deleteWhere("GameId = '$gameId'")
             X01FinishEntity().deleteWhere("GameId = '$gameId'")
             GameEntity().deleteWhere("RowId = '$gameId'")
+            DartzeeRuleEntity().deleteForGame(gameId)
 
-            DialogUtil.showInfoOLD("Game #$localId has been purged.")
+            DialogUtil.showInfo("Game #$localId has been purged.")
         }
     }
 }

--- a/src/main/kotlin/dartzee/utils/DevUtilities.kt
+++ b/src/main/kotlin/dartzee/utils/DevUtilities.kt
@@ -3,8 +3,11 @@ package dartzee.utils
 import dartzee.core.util.DialogUtil
 import dartzee.db.DartEntity
 import dartzee.db.GameEntity
+import dartzee.db.IParticipant
 import dartzee.db.ParticipantEntity
+import dartzee.db.TeamEntity
 import dartzee.db.X01FinishEntity
+import dartzee.game.loadParticipants
 import dartzee.screen.ScreenCache
 import dartzee.utils.InjectedThings.mainDatabase
 import javax.swing.JOptionPane
@@ -60,13 +63,20 @@ object DevUtilities
             return
         }
 
-        val participantIds = ParticipantEntity().retrieveEntities("GameId = '$gameId'").map { it.rowId }
+        val participants = loadParticipants(gameId)
+        val participantEntities: List<IParticipant> = participants.flatMap { it.individuals + it.participant }
+        val participantIds = participantEntities.filterIsInstance<ParticipantEntity>().map { it.rowId }
+        val teamIds = participantEntities.filterIsInstance<TeamEntity>().map { it.rowId }
         val ptSql = participantIds.getQuotedIdStr()
         val dartCount = if (participantIds.isEmpty()) 0 else DartEntity().countWhere("ParticipantId IN $ptSql")
 
-        val question = ("Purge all data for Game #$localId? The following rows will be deleted:"
-                + "\n\n Participant: ${participantIds.size} rows"
-                + "\n Dart: $dartCount rows")
+        val question = """
+            Purge all data for Game #$localId? The following rows will be deleted:
+            
+            Participant: ${participantIds.size} rows
+            Team: ${teamIds.size} rows
+            Dart: $dartCount rows
+        """.trimIndent()
 
         val answer = DialogUtil.showQuestionOLD(question, false)
         if (answer == JOptionPane.YES_OPTION)
@@ -76,6 +86,7 @@ object DevUtilities
                 DartEntity().deleteWhere("ParticipantId IN $ptSql")
             }
 
+            TeamEntity().deleteWhere("GameId = '$gameId'")
             ParticipantEntity().deleteWhere("GameId = '$gameId'")
             X01FinishEntity().deleteWhere("GameId = '$gameId'")
             GameEntity().deleteWhere("RowId = '$gameId'")

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -1,6 +1,8 @@
 package dartzee
 
 import com.github.alyssaburlton.swingtest.clickChild
+import com.github.alyssaburlton.swingtest.clickOk
+import com.github.alyssaburlton.swingtest.clickYes
 import com.github.alyssaburlton.swingtest.doClick
 import com.github.alyssaburlton.swingtest.findAll
 import com.github.alyssaburlton.swingtest.findWindow
@@ -27,6 +29,7 @@ import dartzee.`object`.DartboardSegment
 import dartzee.`object`.SegmentType
 import dartzee.screen.GameplayDartboard
 import dartzee.screen.PlayerImageDialog
+import dartzee.utils.DevUtilities
 import dartzee.utils.getAverage
 import io.kotest.matchers.doubles.shouldBeBetween
 import io.kotest.matchers.maps.shouldContainExactly
@@ -246,6 +249,26 @@ fun <T> runAsync(block: () -> T?): T? {
 
     flushEdt()
     return result
+}
+
+fun purgeGameAndConfirm(localId: Long): String {
+    runAsync { DevUtilities.purgeGame(localId) }
+
+    return confirmGameDeletion(localId)
+}
+
+fun confirmGameDeletion(localId: Long): String {
+    val dlg = getQuestionDialog()
+    val questionText = dlg.getDialogMessage()
+    dlg.clickYes()
+    flushEdt()
+
+    val info = getInfoDialog()
+    info.getDialogMessage() shouldBe "Game #$localId has been purged."
+    info.clickOk()
+    flushEdt()
+
+    return questionText
 }
 
 /**

--- a/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
@@ -177,6 +177,26 @@ class TestDartzeeRuleEntity: AbstractEntityTest<DartzeeRuleEntity>()
     }
 
     @Test
+    fun `Should delete rows for a game`()
+    {
+        val gameA = insertGame()
+        val gameB = insertGame()
+
+        insertDartzeeRule(entityName = EntityName.Game, entityId = gameA.rowId, ordinal = 3)
+        insertDartzeeRule(entityName = EntityName.Game, entityId = gameA.rowId, ordinal = 1)
+        insertDartzeeRule(entityName = EntityName.Game, entityId = gameA.rowId, ordinal = 2)
+
+        val ruleB1 = insertDartzeeRule(entityName = EntityName.Game, entityId = gameB.rowId, ordinal = 1)
+        val templateRule = insertDartzeeRule(entityName = EntityName.DartzeeTemplate, entityId = insertDartzeeTemplate().rowId, ordinal = 1)
+
+        DartzeeRuleEntity().deleteForGame(gameA.rowId)
+
+        val remainingRules = DartzeeRuleEntity().retrieveEntities()
+
+        remainingRules.map { it.rowId }.shouldContainExactlyInAnyOrder(ruleB1.rowId, templateRule.rowId)
+    }
+
+    @Test
     fun `Should retrieve rules for a game, sorted by ordinal`()
     {
         val gameA = insertGame()

--- a/src/test/kotlin/dartzee/utils/TestDevUtilities.kt
+++ b/src/test/kotlin/dartzee/utils/TestDevUtilities.kt
@@ -1,15 +1,44 @@
 package dartzee.utils
 
-import dartzee.helper.*
+import com.github.alyssaburlton.swingtest.clickNo
+import com.github.alyssaburlton.swingtest.clickOk
+import com.github.alyssaburlton.swingtest.clickYes
+import com.github.alyssaburlton.swingtest.flushEdt
+import dartzee.db.DartzeeRoundResultEntity
+import dartzee.db.DartzeeRuleEntity
+import dartzee.db.EntityName
+import dartzee.db.ParticipantEntity
+import dartzee.db.TeamEntity
+import dartzee.game.loadParticipants
+import dartzee.game.prepareParticipants
+import dartzee.getDialogMessage
+import dartzee.getErrorDialog
+import dartzee.getInfoDialog
+import dartzee.getQuestionDialog
+import dartzee.helper.AbstractTest
+import dartzee.helper.getCountFromTable
+import dartzee.helper.insertDart
+import dartzee.helper.insertDartzeeRoundResult
+import dartzee.helper.insertFinishForPlayer
+import dartzee.helper.insertGame
+import dartzee.helper.insertParticipant
+import dartzee.helper.insertPlayer
+import dartzee.helper.preparePlayers
+import dartzee.helper.retrieveDart
+import dartzee.helper.retrieveGame
+import dartzee.helper.retrieveParticipant
+import dartzee.helper.retrieveX01Finish
+import dartzee.helper.testRules
+import dartzee.only
+import dartzee.runAsync
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.FakeDartsScreen
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
-import javax.swing.JOptionPane
 
 class TestDevUtilities: AbstractTest()
 {
@@ -33,7 +62,7 @@ class TestDevUtilities: AbstractTest()
         dialogFactory.inputsShown.shouldContainExactly("Delete Game")
         dialogFactory.inputOptionsPresented?.size shouldBe 1
 
-        getCountFromTable("Game") shouldBe 1
+        getCountFromTable(EntityName.Game) shouldBe 1
     }
 
     @Test
@@ -43,14 +72,16 @@ class TestDevUtilities: AbstractTest()
         insertGame(localId = 2)
 
         dialogFactory.inputSelection = 2L
-        dialogFactory.questionOption = JOptionPane.YES_OPTION
 
-        DevUtilities.purgeGame()
+        runAsync { DevUtilities.purgeGame() }
 
         dialogFactory.inputsShown.shouldContainExactly("Delete Game")
         dialogFactory.inputOptionsPresented?.size shouldBe 2
 
-        getCountFromTable("Game") shouldBe 1
+        getQuestionDialog().clickYes()
+        flushEdt()
+
+        getCountFromTable(EntityName.Game) shouldBe 1
         retrieveGame().localId shouldBe 1
     }
 
@@ -59,11 +90,12 @@ class TestDevUtilities: AbstractTest()
     {
         insertGame(localId = 5)
 
-        DevUtilities.purgeGame(10)
+        runAsync { DevUtilities.purgeGame(10) }
 
-        dialogFactory.errorsShown.shouldContainExactly("No game exists for ID 10")
-        dialogFactory.questionsShown.shouldBeEmpty()
-        getCountFromTable("Game") shouldBe 1
+        val dlg = getErrorDialog()
+        dlg.getDialogMessage() shouldBe "No game exists for ID 10"
+        dlg.clickOk()
+        getCountFromTable(EntityName.Game) shouldBe 1
     }
 
     @Test
@@ -73,37 +105,38 @@ class TestDevUtilities: AbstractTest()
 
         ScreenCache.addDartsGameScreen(game.rowId, FakeDartsScreen())
 
-        DevUtilities.purgeGame(5)
+        runAsync { DevUtilities.purgeGame(5) }
 
-        dialogFactory.errorsShown.shouldContainExactly("Cannot delete a game that's open.")
-        dialogFactory.questionsShown.shouldBeEmpty()
-        getCountFromTable("Game") shouldBe 1
+        val dlg = getErrorDialog()
+        dlg.getDialogMessage() shouldBe "Cannot delete a game that's open."
+        dlg.clickOk()
+        getCountFromTable(EntityName.Game) shouldBe 1
     }
 
     @Test
     fun `Should not delete a game if cancelled`()
     {
         insertGame(localId = 5)
-        dialogFactory.questionOption = JOptionPane.NO_OPTION
 
-        DevUtilities.purgeGame(5)
+        runAsync { DevUtilities.purgeGame(5) }
 
-        dialogFactory.questionsShown.shouldHaveSize(1)
-        getCountFromTable("Game") shouldBe 1
+        val dlg = getQuestionDialog()
+        dlg.clickNo()
+        flushEdt()
+
+        getCountFromTable(EntityName.Game) shouldBe 1
     }
 
     @Test
     fun `Should delete from X01Finish`()
     {
-        dialogFactory.questionOption = JOptionPane.YES_OPTION
-
         val player = insertPlayer()
         val gameOne = insertFinishForPlayer(player, 25)
         val gameTwo = insertFinishForPlayer(player, 80)
 
-        DevUtilities.purgeGame(gameOne.localId)
+        purgeGameAndConfirm(gameOne.localId)
 
-        getCountFromTable("X01Finish") shouldBe 1
+        getCountFromTable(EntityName.X01Finish) shouldBe 1
         retrieveX01Finish().gameId shouldBe gameTwo.rowId
         retrieveX01Finish().finish shouldBe 80
     }
@@ -123,23 +156,87 @@ class TestDevUtilities: AbstractTest()
         insertDart(pt2, ordinal = 1, score = 20, multiplier = 2, startingScore = 501)
         insertDart(pt2, ordinal = 2, score = 20, multiplier = 3, startingScore = 461)
 
-        dialogFactory.questionOption = JOptionPane.YES_OPTION
-
-        DevUtilities.purgeGame(2)
-
-        dialogFactory.questionsShown.shouldHaveSize(1)
-        val q = dialogFactory.questionsShown.first()
+        val q = purgeGameAndConfirm(2)
 
         q.shouldContain("Purge all data for Game #2?")
         q.shouldContain("Participant: 1 rows")
         q.shouldContain("Dart: 2 rows")
 
-        getCountFromTable("Game") shouldBe 1
-        getCountFromTable("Participant") shouldBe 1
-        getCountFromTable("Dart") shouldBe 1
+        getCountFromTable(EntityName.Game) shouldBe 1
+        getCountFromTable(EntityName.Participant) shouldBe 1
+        getCountFromTable(EntityName.Dart) shouldBe 1
 
         retrieveGame().rowId shouldBe g1.rowId
         retrieveParticipant().rowId shouldBe pt1.rowId
         retrieveDart().rowId shouldBe d1.rowId
+    }
+
+    @Test
+    fun `Should delete teams associated with a game`()
+    {
+        val players = preparePlayers(5)
+
+        val gameA = insertGame()
+        val gameB = insertGame()
+
+        prepareParticipants(gameA.rowId, players, pairMode = true)
+        prepareParticipants(gameB.rowId, players, pairMode = true)
+
+        getCountFromTable(EntityName.Team) shouldBe 4
+
+        purgeGameAndConfirm(gameA.localId)
+
+        loadParticipants(gameA.rowId).shouldBeEmpty()
+        loadParticipants(gameB.rowId).size shouldBe 3
+
+        ParticipantEntity().countWhere("GameId = '${gameA.rowId}'") shouldBe 0
+        TeamEntity().countWhere("GameId = '${gameA.rowId}'") shouldBe 0
+    }
+
+    @Test
+    fun `Should purge Dartzee gubbins`()
+    {
+        val player = insertPlayer()
+        val g1 = insertGame()
+        val g2 = insertGame()
+
+        val pt1 = insertParticipant(playerId = player.rowId, gameId = g1.rowId)
+        val pt2 = insertParticipant(playerId = player.rowId, gameId = g2.rowId)
+
+        insertDartzeeRules(g1.rowId, testRules)
+        insertDartzeeRules(g2.rowId, testRules)
+
+        insertDartzeeRoundResult(pt1)
+        insertDartzeeRoundResult(pt2)
+
+        getCountFromTable(EntityName.DartzeeRule) shouldBe testRules.size * 2
+        getCountFromTable(EntityName.DartzeeRoundResult) shouldBe 2
+
+        purgeGameAndConfirm(g1.localId)
+
+        getCountFromTable(EntityName.DartzeeRule) shouldBe testRules.size
+
+        val dartzeeRules = DartzeeRuleEntity().retrieveEntities()
+        dartzeeRules.size shouldBe testRules.size
+        dartzeeRules.forAll { it.entityId shouldBe g2.rowId }
+
+        val remainingResult = DartzeeRoundResultEntity().retrieveEntities().only()
+        remainingResult.participantId shouldBe pt2.rowId
+    }
+
+    private fun purgeGameAndConfirm(localId: Long): String {
+        runAsync { DevUtilities.purgeGame(localId) }
+
+        val dlg = getQuestionDialog()
+        val questionText = dlg.getDialogMessage()
+        dlg.clickYes()
+        flushEdt()
+
+        val info = getInfoDialog()
+        info.getDialogMessage() shouldBe "Game #$localId has been purged."
+        info.clickOk()
+        flushEdt()
+
+        return questionText
     }
 }

--- a/src/test/kotlin/dartzee/utils/TestDevUtilities.kt
+++ b/src/test/kotlin/dartzee/utils/TestDevUtilities.kt
@@ -13,7 +13,6 @@ import dartzee.game.loadParticipants
 import dartzee.game.prepareParticipants
 import dartzee.getDialogMessage
 import dartzee.getErrorDialog
-import dartzee.getInfoDialog
 import dartzee.getQuestionDialog
 import dartzee.helper.AbstractTest
 import dartzee.helper.getCountFromTable
@@ -30,6 +29,7 @@ import dartzee.helper.retrieveParticipant
 import dartzee.helper.retrieveX01Finish
 import dartzee.helper.testRules
 import dartzee.only
+import dartzee.purgeGameAndConfirm
 import dartzee.runAsync
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.FakeDartsScreen
@@ -222,21 +222,5 @@ class TestDevUtilities: AbstractTest()
 
         val remainingResult = DartzeeRoundResultEntity().retrieveEntities().only()
         remainingResult.participantId shouldBe pt2.rowId
-    }
-
-    private fun purgeGameAndConfirm(localId: Long): String {
-        runAsync { DevUtilities.purgeGame(localId) }
-
-        val dlg = getQuestionDialog()
-        val questionText = dlg.getDialogMessage()
-        dlg.clickYes()
-        flushEdt()
-
-        val info = getInfoDialog()
-        info.getDialogMessage() shouldBe "Game #$localId has been purged."
-        info.clickOk()
-        flushEdt()
-
-        return questionText
     }
 }

--- a/src/test/kotlin/e2e/SyncE2E.kt
+++ b/src/test/kotlin/e2e/SyncE2E.kt
@@ -4,6 +4,7 @@ import com.github.alyssaburlton.swingtest.clickChild
 import com.github.alyssaburlton.swingtest.findChild
 import com.github.alyssaburlton.swingtest.waitForAssertion
 import dartzee.achievements.AchievementType
+import dartzee.confirmGameDeletion
 import dartzee.db.AchievementEntity
 import dartzee.db.EntityName
 import dartzee.db.GameEntity
@@ -18,6 +19,7 @@ import dartzee.helper.getCountFromTable
 import dartzee.helper.retrieveGame
 import dartzee.helper.retrieveParticipant
 import dartzee.helper.wipeTable
+import dartzee.purgeGameAndConfirm
 import dartzee.screen.DartsApp
 import dartzee.screen.ScreenCache
 import dartzee.screen.UtilitiesScreen
@@ -30,7 +32,6 @@ import dartzee.sync.SyncConfigurer
 import dartzee.sync.SyncManager
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.Database
-import dartzee.utils.DevUtilities
 import dartzee.utils.InjectedThings
 import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
 import dartzee.utils.PREFERENCES_INT_AI_SPEED
@@ -137,7 +138,8 @@ class SyncE2E: AbstractRegistryTest()
         ScreenCache.switch<UtilitiesScreen>()
         dialogFactory.inputSelection = 1L
         dialogFactory.questionOption = JOptionPane.YES_OPTION
-        mainScreen.clickChild<JButton>(text = "Delete Game")
+        mainScreen.clickChild<JButton>(text = "Delete Game", async = true)
+        confirmGameDeletion(1)
     }
 
     private fun runGame(winner: PlayerEntity, loser: PlayerEntity): String
@@ -172,10 +174,11 @@ class SyncE2E: AbstractRegistryTest()
 
     private fun wipeGamesAndResetRemote(mainScreen: DartsApp)
     {
-        dialogFactory.questionOption = JOptionPane.YES_OPTION
-        DevUtilities.purgeGame(1)
+        purgeGameAndConfirm(1)
         wipeTable(EntityName.DeletionAudit)
         wipeTable(EntityName.Achievement)
+
+        dialogFactory.questionOption = JOptionPane.YES_OPTION
         mainScreen.clickChild<JButton>(text = "Reset")
         waitForAssertion { mainScreen.findChild<SyncSetupPanel>() shouldNotBe null }
     }


### PR DESCRIPTION
https://trello.com/c/dpZbwTZ4/268-sanity-check-stuff

(Also a bit more of https://trello.com/c/ab1m8KcG/265-remove-testmessagedialogfactory)

Ensures Teams, DartzeeRules and DartzeeRoundResults are all cleaned up properly when games are deleted. One day all of this can go, when cascade deletion is a thing... :sweat_smile: 