### PR TITLE
Fix bug with local ID generation

### DIFF
--- a/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
+++ b/src/main/kotlin/dartzee/bean/PresentationDartboard.kt
@@ -37,7 +37,7 @@ import javax.swing.SwingConstants
 import kotlin.math.roundToInt
 
 open class PresentationDartboard(
-    protected val colourWrapper: ColourWrapper = getColourWrapperFromPrefs(),
+    private val colourWrapper: ColourWrapper = getColourWrapperFromPrefs(),
     private val renderScoreLabels: Boolean = false
 ) : JComponent(), IDartboard
 {

--- a/src/main/kotlin/dartzee/db/LocalIdGenerator.kt
+++ b/src/main/kotlin/dartzee/db/LocalIdGenerator.kt
@@ -5,7 +5,12 @@ import dartzee.utils.Database
 class LocalIdGenerator(private val database: Database)
 {
     private val uniqueIdSyncObject = Any()
-    val hmLastAssignedIdByEntityName = mutableMapOf<EntityName, Long>()
+    private val hmLastAssignedIdByEntityName = mutableMapOf<EntityName, Long>()
+
+    fun clearCache()
+    {
+        hmLastAssignedIdByEntityName.clear()
+    }
 
     fun generateLocalId(entityName: EntityName): Long
     {

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -229,6 +229,7 @@ object DartsDatabaseUtil
         finally
         {
             mainDatabase.initialiseConnectionPool(connectionPoolSize)
+            mainDatabase.localIdGenerator.clearCache()
         }
 
         return true

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -46,7 +46,7 @@ abstract class AbstractTest
         DialogUtil.init(dialogFactory)
         DartsClient.devMode = false
 
-        mainDatabase.localIdGenerator.hmLastAssignedIdByEntityName.clear()
+        mainDatabase.localIdGenerator.clearCache()
 
         if (logDestination.haveRunInsert)
         {

--- a/src/test/kotlin/dartzee/utils/TestDartsDatabaseUtil.kt
+++ b/src/test/kotlin/dartzee/utils/TestDartsDatabaseUtil.kt
@@ -3,8 +3,18 @@ package dartzee.utils
 import dartzee.db.DatabaseMigrator
 import dartzee.db.EntityName
 import dartzee.db.MigrationResult
-import dartzee.helper.*
-import dartzee.logging.*
+import dartzee.helper.AbstractTest
+import dartzee.helper.TEST_DB_DIRECTORY
+import dartzee.helper.TEST_ROOT
+import dartzee.helper.assertExits
+import dartzee.helper.insertGame
+import dartzee.helper.usingInMemoryDatabase
+import dartzee.logging.CODE_BACKUP_ERROR
+import dartzee.logging.CODE_DATABASE_CREATED
+import dartzee.logging.CODE_DATABASE_CREATING
+import dartzee.logging.CODE_RESTORE_ERROR
+import dartzee.logging.CODE_TEST_CONNECTION_ERROR
+import dartzee.logging.Severity
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.DartsGameScreen
 import dartzee.utils.DartsDatabaseUtil.DATABASE_NAME
@@ -180,9 +190,12 @@ class TestDartsDatabaseUtil: AbstractTest()
     }
 
     @Test
-    fun `Should swap in the selected database if confirmed`()
+    fun `Should swap in the selected database if confirmed, and clear localId cache`()
     {
         usingInMemoryDatabase(withSchema = true) { db ->
+            mainDatabase.generateLocalId(EntityName.Game) shouldBe 1L
+            insertGame(localId = 5L)
+
             dialogFactory.questionOption = JOptionPane.YES_OPTION
             val f = File("${db.getDirectoryStr()}/SomeFile.txt")
             f.createNewFile()
@@ -193,6 +206,8 @@ class TestDartsDatabaseUtil: AbstractTest()
 
             dialogFactory.questionsShown.shouldContainExactly("Successfully connected to target database.\n\nAre you sure you want to restore this database? All current data will be lost.")
             dialogFactory.infosShown.shouldContainExactly("Database restored successfully.")
+
+            mainDatabase.generateLocalId(EntityName.Game) shouldBe 6L
         }
     }
 


### PR DESCRIPTION
Reset the LocalIdGenerator when a database is swapped in, for example after a sync.

Fixes https://trello.com/c/w5IQJCqY/266-sqlexception-trying-to-insert-duplicate-game - in this case what happened was:

 - Launched Dartzee and played some games. The latest game inserted was LocalId 4413.
 - Performed a database sync. There were some pending remote games to download, so the end result was that the swapped in database had localIds up to and including 4415.
 - Tried to launch another game. The `LocalIdGenerator` thinks the next value should be 4414, and the insert fails.