### PR TITLE
Fix `ConcurrentModificationException`

### DIFF
--- a/src/main/kotlin/dartzee/screen/GameplayDartboard.kt
+++ b/src/main/kotlin/dartzee/screen/GameplayDartboard.kt
@@ -72,9 +72,10 @@ class GameplayDartboard(colourWrapper: ColourWrapper = getColourWrapperFromPrefs
 
     fun dartThrown(pt: ComputedPoint)
     {
-        dartsThrown.add(pt)
-
-        runOnEventThreadBlocking { addDartLabel(pt) }
+        runOnEventThreadBlocking {
+            dartsThrown.add(pt)
+            addDartLabel(pt)
+        }
 
         listeners.forEach { it.dartThrown(getDartForSegment(pt.segment)) }
     }


### PR DESCRIPTION
https://trello.com/c/YisUQFze/269-concurrentmodificationexception-gameplaydartboard

Add to the `dartsThrown` list on the event thread, so it can't run concurrently against resize code (which reads from this list in order to layout the actual labels).