### PR TITLE
Detekt main 6

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -62,7 +62,7 @@ style:
   NewLineAtEndOfFile:
     active: false
   ReturnCount:
-    excludeGuardClauses: true
+    active: false
   ThrowsCount:
     active: false
   UnnecessaryAbstractClass:

--- a/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
@@ -39,14 +39,11 @@ data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule
 
         dart1Rule ?: return sumScore(dartsAfterAggregate)
 
-        if (dart2Rule != null)
-        {
-            return sumScore(dartsAfterAggregate)
-        }
-        else
-        {
+        return if (dart2Rule != null) {
+            sumScore(dartsAfterAggregate)
+        } else {
             val validDarts = dartsAfterAggregate.filter { dart1Rule.isValidDart(it) }
-            return sumScore(validDarts)
+            sumScore(validDarts)
         }
     }
 

--- a/src/main/kotlin/dartzee/db/AbstractEntity.kt
+++ b/src/main/kotlin/dartzee/db/AbstractEntity.kt
@@ -121,7 +121,6 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         {
             logger.error(CODE_SQL_EXCEPTION,
                     "Retrieved ${entities.size} rows from ${getTableName()}. Expected 1. WhereSQL [$whereSql]",
-                    Throwable(),
                     KEY_SQL to whereSql)
         }
 
@@ -167,7 +166,6 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         {
             logger.error(CODE_SQL_EXCEPTION,
                     "Failed to find ${getTableName()} for ID [$rowId]",
-                    Throwable(),
                     KEY_SQL to "RowId = '$rowId'")
         }
 
@@ -285,7 +283,6 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
                 {
                     logger.error(CODE_SQL_EXCEPTION,
                             "0 rows updated for statement $updateQuery",
-                            Throwable(),
                             KEY_SQL to updateQuery)
                 }
             }

--- a/src/main/kotlin/dartzee/db/DartsMatchEntity.kt
+++ b/src/main/kotlin/dartzee/db/DartsMatchEntity.kt
@@ -60,7 +60,7 @@ class DartsMatchEntity(database: Database = mainDatabase) : AbstractEntity<Darts
         when(mode)
         {
             MatchMode.FIRST_TO -> if (position == 1) 1 else 0
-            MatchMode.POINTS -> if (position == -1) 0 else getHmPositionToPoints()[position]!!
+            MatchMode.POINTS -> if (position == -1) 0 else getHmPositionToPoints().getValue(position)
         }
 
     private fun getHmPositionToPoints(): Map<Int, Int>

--- a/src/main/kotlin/dartzee/db/ForeignDatabaseValidator.kt
+++ b/src/main/kotlin/dartzee/db/ForeignDatabaseValidator.kt
@@ -32,11 +32,6 @@ class ForeignDatabaseValidator(private val migrator: DatabaseMigrator)
         }
 
         val result = migrator.migrateToLatest(database, desc.replaceFirstChar { it.uppercase() })
-        if (result != MigrationResult.SUCCESS)
-        {
-            return false
-        }
-
-        return true
+        return result == MigrationResult.SUCCESS
     }
 }

--- a/src/main/kotlin/dartzee/logging/Logger.kt
+++ b/src/main/kotlin/dartzee/logging/Logger.kt
@@ -59,7 +59,12 @@ class Logger(private val destinations: List<ILogDestination>)
         log(Severity.WARN, code, message, null, mapOf(*keyValuePairs))
     }
 
-    fun error(code: LoggingCode, message: String, errorObject: Throwable = Throwable(), vararg keyValuePairs: Pair<String, Any?>)
+    fun error(code: LoggingCode, message: String, vararg keyValuePairs: Pair<String, Any?>)
+    {
+        error(code, message, Throwable(message), keyValuePairs=keyValuePairs)
+    }
+
+    fun error(code: LoggingCode, message: String, errorObject: Throwable = Throwable(message), vararg keyValuePairs: Pair<String, Any?>)
     {
         log(Severity.ERROR, code, message, errorObject, mapOf(*keyValuePairs, KEY_EXCEPTION_MESSAGE to errorObject.message))
     }

--- a/src/main/kotlin/dartzee/screen/AbstractPlayerConfigurationDialog.kt
+++ b/src/main/kotlin/dartzee/screen/AbstractPlayerConfigurationDialog.kt
@@ -47,7 +47,7 @@ abstract class AbstractPlayerConfigurationDialog(protected val saveCallback: (pl
 
     private fun isValidName(name: String?): Boolean
     {
-        if (name == null || name.isEmpty())
+        if (name.isNullOrEmpty())
         {
             DialogUtil.showErrorOLD("You must enter a name for this player.")
             return false

--- a/src/main/kotlin/dartzee/screen/game/rtc/GameStatisticsPanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/GameStatisticsPanelRoundTheClock.kt
@@ -49,12 +49,12 @@ open class GameStatisticsPanelRoundTheClock(gameParams: String): AbstractGameSta
 
     private fun getBruceys(desc: String, enforceSuccess: Boolean) = prepareRow(desc) { playerName ->
         val rounds = hmPlayerToDarts[playerName].orEmpty()
-        rounds.filter { it.size == 4 }.count { it.last().hitClockTarget(config.clockType) || !enforceSuccess }
+        rounds.count { it.size == 4 && it.last().hitClockTarget(config.clockType) || !enforceSuccess }
     }
 
     private fun getDartsPerNumber(min: Int, max: Int, desc: String = "$min - $max") = prepareRow(desc) { playerName ->
         val dartsGrouped = getDartsGroupedByParticipantAndNumber(playerName)
-        dartsGrouped.filter { it.last().hitClockTarget(config.clockType) }.count { it.size in min..max }
+        dartsGrouped.count { it.size in min..max && it.last().hitClockTarget(config.clockType) }
     }
 
     private fun getDartsPerNumber(desc: String,

--- a/src/main/kotlin/dartzee/screen/game/rtc/GameStatisticsPanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/GameStatisticsPanelRoundTheClock.kt
@@ -49,7 +49,7 @@ open class GameStatisticsPanelRoundTheClock(gameParams: String): AbstractGameSta
 
     private fun getBruceys(desc: String, enforceSuccess: Boolean) = prepareRow(desc) { playerName ->
         val rounds = hmPlayerToDarts[playerName].orEmpty()
-        rounds.count { it.size == 4 && it.last().hitClockTarget(config.clockType) || !enforceSuccess }
+        rounds.count { it.size == 4 && (it.last().hitClockTarget(config.clockType) || !enforceSuccess) }
     }
 
     private fun getDartsPerNumber(min: Int, max: Int, desc: String = "$min - $max") = prepareRow(desc) { playerName ->

--- a/src/main/kotlin/dartzee/screen/stats/player/x01/StatisticsTabX01ThreeDartAverage.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/x01/StatisticsTabX01ThreeDartAverage.kt
@@ -114,7 +114,7 @@ class StatisticsTabX01ThreeDartAverage : AbstractStatisticsTab()
         val allScoringDarts = sortedGames.flatMap { it.getScoringDarts(scoreThreshold) }
 
         val totalScoringDarts = allScoringDarts.size.toDouble()
-        val misses = allScoringDarts.filter { it.multiplier == 0 }.size.toDouble()
+        val misses = allScoringDarts.count { it.multiplier == 0 }.toDouble()
         val overallThreeDartAvg = 3 * allScoringDarts.sumOf { it.getTotal() } / allScoringDarts.size.toDouble()
 
         val rawAverages = XYSeries("Avg$graphSuffix")

--- a/src/main/kotlin/dartzee/utils/UpdateManager.kt
+++ b/src/main/kotlin/dartzee/utils/UpdateManager.kt
@@ -56,7 +56,6 @@ object UpdateManager
             {
                 logger.error(CODE_UPDATE_ERROR,
                         "Received non-success HTTP status: ${response.status} - ${response.statusText}",
-                        Throwable(),
                         KEY_RESPONSE_BODY to response.body)
                 DialogUtil.showError("Failed to check for updates (unable to connect).")
                 return null


### PR DESCRIPTION
Disable `ReturnCount`, it's mostly flagging methods like:

```
fun valid(): Boolean {
    if (!conditionOne) {
        DialogUtil.showError("First thing is wrong")
        return false
    }
    
    if (!conditionTwo) {
        ....
    }
    
    ...
    
    return true
}
```

:shrug: 

Also fixing:

 - UnnecessaryFilter
 - MapGetWithNotNullAssertionOperator
 - ThrowingExceptionsWIthoutMessageorCause
 - UseIsNullOrEmpty

33 left