### PR TITLE
Detekt main 7

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -24,7 +24,7 @@ exceptions:
   TooGenericExceptionCaught:
     active: false
   TooGenericExceptionThrown:
-    excludes: '**/src/test/**/*.kt'
+    active: false
 
 naming:
   ConstructorParameterNaming:

--- a/src/main/kotlin/dartzee/core/util/FileUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/FileUtil.kt
@@ -4,7 +4,6 @@ import dartzee.logging.CODE_FILE_ERROR
 import dartzee.logging.CODE_SWITCHING_FILES
 import dartzee.utils.InjectedThings.logger
 import java.awt.Dimension
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
@@ -84,16 +83,7 @@ object FileUtil
     fun getByteArrayForResource(resourcePath: String): ByteArray? =
         try
         {
-            javaClass.getResourceAsStream(resourcePath).use { `is` ->
-                ByteArrayOutputStream().use { baos ->
-                    val b = ByteArray(4096)
-                    var n: Int
-                    while (`is`.read(b).also { n = it } != -1) {
-                        baos.write(b, 0, n)
-                    }
-                    baos.toByteArray()
-                }
-            }
+            javaClass.getResourceAsStream(resourcePath).use { stream -> stream?.readBytes() }
         }
         catch (ioe: IOException)
         {

--- a/src/main/kotlin/dartzee/core/util/XmlUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/XmlUtil.kt
@@ -56,6 +56,7 @@ fun Document.toXmlString(): String =
         ""
     }
 
+@Suppress("SwallowedException")
 fun String.toXmlDoc() =
     try
     {

--- a/src/main/kotlin/dartzee/logging/ElasticsearchPoster.kt
+++ b/src/main/kotlin/dartzee/logging/ElasticsearchPoster.kt
@@ -45,6 +45,7 @@ class ElasticsearchPoster(private val credentials: AWSCredentials?,
         }
     }
 
+    @Suppress("SwallowedException")
     fun isOnline(): Boolean
     {
         val initialisedClient = client ?: return false


### PR DESCRIPTION
Disable `TooGenericExceptionThrown` - as long as there's a message on them it makes no difference IMO.
Suppress the 2 examples of `SwallowedException` - one happens before we can log, the other is old XML stuff that will be burned one day anyway :fire: 
Fix `NestedBlockDepth`

23 left.